### PR TITLE
docs: add battle-history rollout runbook

### DIFF
--- a/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
+++ b/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
@@ -2,13 +2,30 @@
 
 _Created: 2026-04-28_
 _Context: Take the lil_boots incremental-battle PoC (`runbook-incremental-battle-poc-2026-04-27.md`) playerbase-wide as a longitudinal "your last week of battles" feature, surfaced per ship per day for any player on the site. Reuses existing refresh paths so no new WG calls are introduced._
-_Status: Design draft. Depends on the PoC runbook landing first (its migration + `incremental_battles.py` orchestrator are prerequisites)._
+_Status: Implementation complete on local branches; ready to push, open PRs, and execute the production rollout sequence below. All curated release gates pass (backend 268+, frontend 88), with one pre-existing unrelated failure deselected._
 
 ## Purpose
 
 Battlestats today shows running totals only. The PoC proved that diffing two consecutive snapshots of WG `account/info/` + `ships/stats/` yields per-ship per-match deltas (battles, wins, frags, damage, xp, planes_killed, survived). This rollout takes that mechanism playerbase-wide as a longitudinal record — "show me my last 7 days of battles, by ship and by day" — for any player on the site. Multi-match collapse between observations is acceptable; what matters is that **daily totals per ship are stable and trend over time**.
 
 The PoC's "poll every 60 s" model does not scale: applied to even a small fraction of the 274 K-player base it would saturate the WG `application_id` rate budget. The rollout instead **piggybacks capture on the WG calls the site already makes** during visit-driven and incremental-crawl refreshes, then layers a denormalized daily roll-up table optimized for longitudinal reads.
+
+## Implementation status
+
+All eight rollout phases are committed locally on independent feature branches and pass their respective release gates. They are deploy-ready in the order below; pushing them to GitHub and merging into `main` is the first action the engineer rolling this out should take.
+
+| Phase | Branch | Commit | Flag landed (default off in prod) | Tests |
+|---|---|---|---|---|
+| 0 — PoC tree | `feature/incremental-battles-poc` | `d49600c` | `BATTLE_TRACKING_PLAYER_NAMES` (empty in prod) | smoke + lil_boots live capture |
+| Runbook reconcile | `runbook/battle-history-rollout-2026-04-28` | `51a86f1` (this commit) | docs only | n/a |
+| 1 — Orchestrator refactor | `feature/battle-history-phase1-refactor` | `e949320` | none (refactor) | 18 new pytest cases |
+| 2 — Capture hook | `feature/battle-history-phase2-capture-hook` | `28ef5ae` | `BATTLE_HISTORY_CAPTURE_ENABLED` | 22 cumulative |
+| 3 — Rollup table + writers | `feature/battle-history-phase3-rollup` | `8a4e60b` | `BATTLE_HISTORY_ROLLUP_ENABLED` | 30 cumulative |
+| 4 — Read API | `feature/battle-history-phase4-api` | `e14ee51` | `BATTLE_HISTORY_API_ENABLED` | 36 cumulative |
+| 4.6 — Lifetime + delta | `feature/battle-history-phase4.6-vs-lifetime` | `9005d61` | none (extends API) | 39 cumulative |
+| 5 — Frontend `BattleHistoryCard` | `feature/battle-history-phase5-frontend` | `b3b0a79` | gated by API flag | 88 frontend |
+
+Migrations 0051 / 0052 / 0053 are additive `CreateModel` / `AddField` only — no `AlterField` on existing tables, no `NOT NULL` columns added. The deploy script's `python manage.py migrate --noinput` (`server/deploy/deploy_to_droplet.sh:437`) applies them on the first deploy. Tables exist but stay empty until the corresponding env flag is flipped on.
 
 ## Premise: capture is a side-effect, not a poll
 
@@ -21,13 +38,9 @@ Result: every player whose page is visited or whose tier rotates through the inc
 
 ## Dependencies
 
-This runbook is a follow-on to the PoC. The PoC tranche is built and verified locally — see `feature/incremental-battles-poc` (commit `d49600c`) — and lands as a separate PR ahead of this rollout. Specifically, by the time the rollout phases begin, the PoC commit will already provide:
+All prerequisite phases (PoC + Phases 1–5 + 4.6) are committed locally on the branches listed in **Implementation status**. The first task in the rollout is pushing those eight branches and opening their PRs in the order shown.
 
-1. Migrations `0051_battle_observation_event.py` (creates `BattleObservation` + `BattleEvent`) and `0052_battle_event_combat_metrics.py` (adds `damage_delta`, `xp_delta`, `planes_killed_delta`).
-2. `server/warships/incremental_battles.py` with `record_observation_and_diff(player_id, realm)`, `compute_battle_events`, and the per-ship `ShipSnapshot` shape that already includes `damage_dealt`, `xp`, `planes_killed`, and `survived_battles` — i.e. the wider `ships_stats_json` shape this runbook anticipates is already in tree on the PoC commit, no further widening required.
-3. `BATTLE_TRACKING_PLAYER_NAMES` env var support and the `poll-tracked-player-battles` Beat schedule (`server/warships/tasks.py` and `server/warships/signals.py`).
-
-The PoC's 60-second poll loop and `BATTLE_TRACKING_PLAYER_NAMES` env var stay intact through the rollout. The rollout coexists with the PoC; they share the same orchestrator function (`record_observation_from_payloads`, introduced in Phase 1 of the rollout as a refactor of the PoC's `record_observation_and_diff`).
+The PoC's 60-second poll loop and `BATTLE_TRACKING_PLAYER_NAMES` env var stay intact through the rollout. The rollout coexists with the PoC; they share the same orchestrator function (`record_observation_from_payloads`, introduced in Phase 1 as a refactor of the PoC's `record_observation_and_diff`).
 
 ## Design
 
@@ -202,16 +215,94 @@ If this tranche lands backend-only first, data accumulates while the frontend is
 - Backfill: management command `python manage.py rebuild_player_daily_ship_stats --since 2026-04-28` rebuilds rows from `BattleEvent`. No historical backfill is needed for the first week (events only exist from when capture turned on).
 - Rollback: drop `PlayerDailyShipStats` (single reverse migration). No FKs from existing tables point into it.
 
-## Rollout staging (gated, reversible)
+## Production rollout sequence
 
-Each stage is gated by an independent env flag so the team can stop or roll back any individual step.
+Five stages over ~2 weeks. Every flag flip is an edit to the droplet's `/etc/battlestats-server.env` (or `/etc/battlestats-celery.env`) followed by `systemctl restart battlestats-server battlestats-celery battlestats-celery-beat`. **No code change is required between stages** — `os.getenv` is read at runtime, so a worker restart is enough to pick up the new flag value.
 
-1. **Capture-only.** Deploy the `record_observation_from_payloads` hook. Flip `BATTLE_HISTORY_CAPTURE_ENABLED=1` on the droplet. Observations + events accumulate; no UI yet. Watch for 2 days under real load to confirm that `BattleObservation` write volume matches expected refresh volume and that `BattleEvent` rows appear for known-active players.
-2. **Roll-up.** Deploy nightly task + on-write incremental + the new table migration. Flip `BATTLE_HISTORY_ROLLUP_ENABLED=1`. Watch the table grow; spot-check daily totals against `BattleEvent` aggregates with the validation queries below.
-3. **API + UI.** Flip `BATTLE_HISTORY_API_ENABLED=1` to expose `/api/player/.../battle-history`. Ship `BattleHistoryCard.tsx` in the same deploy or defer.
-4. **Pruning.** Enable `cleanup_old_battle_observations_task` after 14 days of data exist.
+### Day 0 — deploy code with all flags off
 
-Kill switch: unset any of the env flags. Tables remain (harmless).
+1. Push the eight branches in the order listed in **Implementation status**, open PRs, merge each in order.
+2. Run `./server/deploy/deploy_to_droplet.sh battlestats.online`. Migrations 0051 / 0052 / 0053 apply. Tables exist but stay empty.
+3. Verify zero log noise on the droplet: `journalctl -u battlestats-server -u battlestats-celery --since "5 minutes ago"`.
+
+### Day 1 — `BATTLE_HISTORY_CAPTURE_ENABLED=1`
+
+Restart server + workers. Watch for 24–48 h:
+
+```sql
+-- Should see hundreds per hour at steady state.
+SELECT count(*) FROM warships_battleobservation WHERE observed_at > now() - interval '1 hour';
+
+-- Storage envelope check.
+SELECT pg_size_pretty(pg_total_relation_size('warships_battleobservation'));
+```
+
+Expected envelope: ~10 K rows/day per realm at steady state, ~30–60 KB/row, so **≤ 7 GB per realm before pruning kicks in**. If growth exceeds the envelope, drop or extend the active-ships filter in `incremental_battles.py:_serialize_ships_payload` (only ships with `pvp.battles > 0`) before stage 2.
+
+### Day 3 — `BATTLE_HISTORY_ROLLUP_ENABLED=1`
+
+On-write incremental + nightly sweeper (04:30 UTC) start filling `PlayerDailyShipStats`. Spot-check after one beat tick:
+
+```sql
+SELECT date, COUNT(*) FROM warships_playerdailyshipstats GROUP BY date ORDER BY date DESC LIMIT 5;
+```
+
+Cross-validate aggregates for any sample player:
+
+```sql
+-- Period totals from BattleEvent and PlayerDailyShipStats must match for any (player, day).
+SELECT SUM(battles_delta), SUM(damage_delta) FROM warships_battleevent
+  WHERE player_id=? AND detected_at::date = '2026-MM-DD';
+SELECT SUM(battles), SUM(damage) FROM warships_playerdailyshipstats
+  WHERE player_id=? AND date = '2026-MM-DD';
+```
+
+### Day 5 — `BATTLE_HISTORY_API_ENABLED=1` + frontend ship
+
+Flip the API flag. `GET /api/player/<name>/battle-history?days=N` goes live. Curl-verify against a known-active player; expect p95 < 50 ms warm, < 200 ms cold. Frontend deploy ships `BattleHistoryCard` in the same window — the card silently no-ops when `totals.battles=0`, so cold-start players see nothing extra on their detail page.
+
+### Day 14+ — pruning
+
+Once at least 14 days of capture data exist, enable retention:
+
+```bash
+# Dry-run first to confirm the row count targeted matches expectation.
+python manage.py rebuild_player_daily_ship_stats --since 2026-MM-DD --dry-run  # use as a similar-shape probe
+```
+
+Then set `BATTLE_OBSERVATION_RETENTION_DAYS=14` on the droplet env. Daily prune sweeps `BattleObservation` rows older than 14 days. `BattleEvent` and `PlayerDailyShipStats` rows are untouched.
+
+Reversibility: un-flip any flag at any stage and the system returns to its pre-rollout behavior. Tables remain (harmless). No production data is on the line until day 14.
+
+## Scaling to all active players
+
+Capture is automatic — it's a side-effect of the WG calls the site already makes:
+
+- `incremental_player_refresh_task` (`server/warships/tasks.py:1138`) walks every NA / EU / Asia player every ~3 h and calls `update_player_data` → `update_battle_data`. Phase 2's hook captures every one of those refreshes for free. **No new WG API budget consumed.**
+- Visit-driven `/api/player/<name>/` hits add real-time coverage for the active-fan slice.
+
+**Optional accelerator for seeding.** If you want every active player observed within 24 h of flipping the capture flag, temporarily lower `PLAYER_REFRESH_INTERVAL_MINUTES` from `180` to `60` for one cycle. Triples observation rate, then revert. Existing infrastructure does the work — no new code, no new WG calls beyond what the existing crawl already issues.
+
+## Operational watchpoints
+
+- **Storage growth** in `warships_battleobservation`. Pruning at day-14 is non-negotiable. Watch `pg_total_relation_size` daily during the first two weeks; if it overshoots the ~7 GB/realm envelope before pruning enables, narrow the per-ship JSON shape (`incremental_battles.py:_serialize_ships_payload`) first rather than disabling capture.
+- **Worker queue depth.** Each `update_battle_data` now does an extra DB write + diff (negligible per call). Watch `celery -A battlestats inspect active` after the capture flip; if depth climbs unexpectedly the diff is hot-pathing somewhere it shouldn't.
+- **API p95 latency** on `/api/player/.../battle-history`. Should be sub-50 ms warm, sub-200 ms cold. The cold case for a player with thousands of `PlayerDailyShipStats` rows is the worst-case shape — load-test before flipping.
+- **Cache invalidation.** The 5-min Redis TTL is forgiving. If immediate freshness on the card after a player refresh is wanted, hook the existing `update_player_data` callsite to `cache.delete_pattern("...battle-history*")`. Optional, costs a few % of refresh latency.
+
+## Freshness reference
+
+[wows-numbers.com](https://wows-numbers.com), the canonical community Personal-Rating source, updates its expected-values dataset no more than every 15 minutes. That's a useful baseline for what counts as "fresh enough" in this domain:
+
+- The **PoC's 60 s poll** for `lil_boots` is 15× tighter than the community baseline — appropriate for the dev loop where we want sub-minute observation; overkill for population-averages math.
+- **Visit-driven captures match** the 15-min benchmark whenever a player's page is loaded.
+- The **3 h incremental-crawl cadence** is the lagging edge — coarse for population-averages staleness but plenty for the "your last week of battles" feature this rollout is delivering.
+
+When the future first-party expected-values phase lands (see **Out of scope** below), the nightly aggregator at 04:30 UTC is the right cadence: our underlying samples already match wows-numbers' 15-min freshness for active players, and recomputing rolling averages once a day from a fresh pile of samples is the correct cadence for *aggregates*, not individual samples.
+
+## Kill switch
+
+Unset any of `BATTLE_HISTORY_CAPTURE_ENABLED`, `BATTLE_HISTORY_ROLLUP_ENABLED`, or `BATTLE_HISTORY_API_ENABLED` and `systemctl restart` the workers + server. The corresponding behavior is dormant on the next tick. Tables and any captured data remain in place (harmless).
 
 ## Validation
 
@@ -240,12 +331,17 @@ The one cost is **storage and write amplification**: every refresh now writes a 
 - `ships_stats_json` only includes ships where `pvp.battles > 0` (4–8× shrink).
 - Postgres `jsonb` is already efficient; if size becomes a problem, a follow-on can compress to `bytea` + zstd.
 
-## Out of scope
+## Out of scope (filed for future phases)
 
-- Per-match-level resolution (the WG API has no per-match endpoint; multi-match collapse is acceptable).
-- Co-op / scenario / operations battles — only `pvp.battles` is tracked; non-PvP modes are silent.
-- Authenticated "log in to see _your_ history" — battlestats has no auth surface today; the read path is `/api/player/<name>/battle-history`, addressable to anyone who knows a name. Privacy is identical to the existing player-detail page.
-- Replacing the PoC's 60 s loop for `lil_boots` — the rollout coexists.
+Filed here so a future engineer knows what got deliberately deferred and where the design notes live.
+
+- **Per-match-level resolution.** The WG API has no per-match endpoint; multi-match collapse between observations is acceptable. Out forever.
+- **Co-op / scenario / operations battles.** Only `pvp.battles` is tracked; non-PvP modes are silent in the current shape.
+- **Authenticated "log in to see _your_ history."** Battlestats has no auth surface today; the read path is `/api/player/<name>/battle-history`, addressable to anyone who knows a name. Privacy is identical to the existing player-detail page.
+- **Ranked battles (Phase 7).** WG exposes per-season per-ship ranked stats at `seasons/shipstats/`; the codebase already wraps it as `_fetch_ranked_ship_stats_for_player` (`server/warships/api/ships.py`). Same diff-and-aggregate pattern as randoms, but each event needs a `mode='ranked'` tag and `BattleObservation` needs a parallel `ranked_ships_stats_json` to hold the prior totals. Land once randoms is stable in production.
+- **First-party expected values (Phase 8).** Once population coverage is meaningful (~2 weeks post-capture-on), aggregate `BattleObservation.ships_stats_json` across all players to compute per-ship population averages — our own equivalent of wows-numbers' expected-values dataset. Surfaces "vs field" badges on the `BattleHistoryCard`. Cold-start gate: suppress the comparison until `sample_battles >= 50` per ship. Nightly aggregator at 04:30 UTC matches the freshness reference above.
+- **Compression (Phase 9).** Move `ships_stats_json` to `bytea` + zstd, or null it out on rows older than the active diff window (only the most recent observation per player is consulted by `compute_battle_events`; everything else is cold history). Open only if real storage measurements during the rollout justify it.
+- **Replacing the PoC's 60 s loop for `lil_boots`** — the rollout coexists with the PoC indefinitely. The PoC stays valuable as a high-frequency reference signal to spot-check the lower-cadence rollout against.
 
 ## File map (touch list for the implementation tranche)
 

--- a/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
+++ b/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
@@ -1,0 +1,292 @@
+# Runbook: Battle History Rollout (Playerbase, Longitudinal)
+
+_Created: 2026-04-28_
+_Context: Take the lil_boots incremental-battle PoC (`runbook-incremental-battle-poc-2026-04-27.md`) playerbase-wide as a longitudinal "your last week of battles" feature, surfaced per ship per day for any player on the site. Reuses existing refresh paths so no new WG calls are introduced._
+_Status: Design draft. Depends on the PoC runbook landing first (its migration + `incremental_battles.py` orchestrator are prerequisites)._
+
+## Purpose
+
+Battlestats today shows running totals only. The PoC proved that diffing two consecutive snapshots of WG `account/info/` + `ships/stats/` yields per-ship per-match deltas (battles, wins, frags, damage, xp, planes_killed, survived). This rollout takes that mechanism playerbase-wide as a longitudinal record — "show me my last 7 days of battles, by ship and by day" — for any player on the site. Multi-match collapse between observations is acceptable; what matters is that **daily totals per ship are stable and trend over time**.
+
+The PoC's "poll every 60 s" model does not scale: applied to even a small fraction of the 274 K-player base it would saturate the WG `application_id` rate budget. The rollout instead **piggybacks capture on the WG calls the site already makes** during visit-driven and incremental-crawl refreshes, then layers a denormalized daily roll-up table optimized for longitudinal reads.
+
+## Premise: capture is a side-effect, not a poll
+
+The Wargaming public API has no per-match endpoint. Per-battle deltas are still computed by diffing successive aggregate snapshots, exactly as in the PoC. The change vs. the PoC is **when** snapshots are taken:
+
+- **PoC**: dedicated `poll_tracked_player_battles_task` issues 2 WG calls per tick per tracked player. Stays in place for `lil_boots` and tests.
+- **Rollout**: snapshots are recorded as a side effect of `update_battle_data` (`server/warships/data.py:2365`), which already fetches `ships/stats/` and is the chokepoint for both visit-driven refreshes (`update_battle_data_task`) and the incremental crawl path (`refresh_player_detail_payloads` → `update_battle_data`). At the tail of that function the WG payload is already in scope and the `Player` row has the freshest aggregates from the most recent `update_player_data`.
+
+Result: every player whose page is visited or whose tier rotates through the incremental crawl gets a `BattleObservation` with **no incremental WG cost**. Resolution is whatever the existing refresh cadence is (instant on visit, ~3 h via incremental crawl).
+
+## Dependencies
+
+This runbook is a follow-on to the PoC. Before the rollout tranche can land:
+
+1. The PoC migration (`0051_battleobservation_battleevent.py` or equivalent) must be generated and applied. The PoC scaffolds `BattleObservation` and `BattleEvent` in `server/warships/models.py:436,473` but no migration exists yet.
+2. `server/warships/incremental_battles.py` must exist with `record_observation_and_diff(player_id, realm)`. It is referenced from `server/warships/tasks.py:1339` but the file is not in tree today.
+3. The PoC's `BattleObservation.ships_stats_json` shape must be widened (see "Storage shape" below) before any data is written, since the rollout's `BattleEvent.damage_delta` / `xp_delta` / `planes_killed_delta` / `survived` columns require it.
+
+The PoC's 60-second poll loop and `BATTLE_TRACKING_PLAYER_NAMES` env var stay intact. The rollout coexists with it; they share the same orchestrator function.
+
+## Design
+
+### Capture: piggyback hook in `update_battle_data`
+
+Refactor the orchestrator into two callable forms in `server/warships/incremental_battles.py`:
+
+- `record_observation_from_payloads(player, player_data, ship_data)` — **new**. Writes a `BattleObservation` from the in-memory WG payloads, loads the previous observation, computes per-ship deltas, and writes `BattleEvent` rows. Does not issue any WG calls.
+- `record_observation_and_diff(player_id, realm)` — **existing wrapper**. Fetches `account/info/` + `ships/stats/`, then calls the new function. Used by the lil_boots PoC poll task and by tests.
+
+Hook point: tail of `update_battle_data` (`server/warships/data.py:2365`), placed after `player.save()` and `refresh_player_explorer_summary(...)`. At that point:
+
+- `ship_data` is the raw WG payload that's already been fetched (line 2391).
+- `player.pvp_battles` / `pvp_wins` / etc. are fresh on the row from the most recent `update_player_data` (which always runs before `update_battle_data` on every entry path).
+
+Gated by env flag `BATTLE_HISTORY_CAPTURE_ENABLED` (default off). Off ⇒ the function returns immediately and the system is byte-for-byte identical to today.
+
+```python
+# at end of update_battle_data, after refresh_player_explorer_summary(...)
+if os.getenv("BATTLE_HISTORY_CAPTURE_ENABLED", "0") == "1":
+    from warships.incremental_battles import record_observation_from_payloads
+    try:
+        record_observation_from_payloads(player, player_data=None, ship_data=ship_data)
+    except Exception:
+        logging.exception("battle-history capture failed for %s", player.player_id)
+```
+
+(The function reads `pvp_battles` etc. from the `player` row, so the second arg can be `None` — keep the parameter for the PoC wrapper which has the raw `account/info/` payload in scope.)
+
+The hook never raises into the refresh path: failures are logged and swallowed so a capture bug cannot regress the existing `update_battle_data` contract.
+
+### Storage shape
+
+#### Widened observation (modifies the PoC schema before any data lands)
+
+The PoC's `ships_stats_json` was specced as compact `{ship_id: {battles, wins, losses, frags}}`. To support the rollout's full delta vocabulary, **before the PoC migration lands** widen the per-ship JSON shape to:
+
+```json
+{
+  "<ship_id>": {
+    "battles": int,
+    "wins": int,
+    "losses": int,
+    "frags": int,
+    "damage_dealt": int,
+    "original_xp": int,
+    "planes_killed": int,
+    "survived_battles": int
+  }
+}
+```
+
+Stored only for ships where `pvp.battles > 0`. Most accounts have touched <100 of the ~548 ships in the game, so this filter cuts the JSON 4–8× vs. storing every ship.
+
+No DB migration is required for this change — `ships_stats_json` is already a `JSONField`. The PoC orchestrator just writes a richer dict.
+
+#### New table: `PlayerDailyShipStats`
+
+Denormalized daily roll-up, optimized for "last N days per ship per player":
+
+```python
+class PlayerDailyShipStats(models.Model):
+    player           = models.ForeignKey(Player, on_delete=models.CASCADE,
+                                         related_name='daily_ship_stats')
+    date             = models.DateField(db_index=True)
+    ship_id          = models.BigIntegerField(db_index=True)
+    ship_name        = models.CharField(max_length=200, blank=True, default='')
+    battles          = models.IntegerField(default=0)
+    wins             = models.IntegerField(default=0)
+    losses           = models.IntegerField(default=0)
+    frags            = models.IntegerField(default=0)
+    damage           = models.BigIntegerField(default=0)
+    xp               = models.BigIntegerField(default=0)
+    planes_killed    = models.IntegerField(default=0)
+    survived_battles = models.IntegerField(default=0)
+    first_event_at   = models.DateTimeField(null=True, blank=True)
+    last_event_at    = models.DateTimeField(null=True, blank=True)
+    updated_at       = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['player', 'date', 'ship_id'],
+                name='unique_player_daily_ship_stats',
+            ),
+        ]
+        indexes = [
+            models.Index(fields=['player', '-date'],
+                         name='daily_ship_player_date_idx'),
+            models.Index(fields=['player', 'ship_id', '-date'],
+                         name='daily_ship_player_ship_date_idx'),
+            models.Index(fields=['date', '-battles'],
+                         name='daily_ship_date_battles_idx'),
+        ]
+```
+
+This is the table the UI reads. A 7-day query for any player is `7 × ~handful-of-ships` rows, sub-millisecond at any scale.
+
+### Aggregation: dual-writer, both idempotent
+
+Two writers, both gated by `BATTLE_HISTORY_ROLLUP_ENABLED`, both idempotent on the `(player, date, ship_id)` unique key:
+
+1. **On-write incremental.** When `record_observation_from_payloads` creates `BattleEvent` rows, also `update_or_create` the matching `PlayerDailyShipStats` row using `event.detected_at::date` and `+= delta` semantics. Inside the same `transaction.atomic()` block as the `BattleEvent` insert so a partial failure cannot produce phantom events.
+2. **Nightly sweeper** — `roll_up_player_daily_ship_stats_task`, Celery Beat at 04:30 UTC. Walks `BattleEvent` rows for the _previous calendar day_ and rebuilds `PlayerDailyShipStats` from scratch for that date. Catches anything the on-write path missed (e.g. events whose detected_at crossed a date boundary, observations that arrived late from a delayed worker). Idempotent because it deletes-then-rewrites rows for the target date.
+
+Both writers share a helper `_apply_event_to_daily_summary(event)` so the math lives in one place.
+
+### Pruning
+
+`BattleObservation` rows are heavy: each one carries a per-ship JSON (~30–60 KB). At playerbase scale this is the dominant cost.
+
+- `cleanup_old_battle_observations_task` — Celery Beat daily, deletes `BattleObservation` rows older than `BATTLE_OBSERVATION_RETENTION_DAYS` (default 14).
+- `BattleEvent` rows are small (one per detected match per ship) and stay 90 days, then prune.
+- `PlayerDailyShipStats` rows are small and retained indefinitely (the durable artifact).
+
+Pruning is the **last** rollout step, enabled only after 14 days of data exist — otherwise the cleanup task would prune the only data we have.
+
+### API
+
+New DRF endpoint: `GET /api/player/<player_name>/battle-history?days=7` in `server/warships/views.py` via `@api_view(['GET'])`. Kept as a separate, cacheable surface — **not** folded into the existing player-detail payload — so it can be paged, parameterized, and cached independently.
+
+Reads only `PlayerDailyShipStats`, joined to `Ship` for tier/type display. No WG calls on the read path.
+
+Response shape:
+
+```json
+{
+  "window_days": 7,
+  "as_of": "2026-04-28T04:30:00Z",
+  "totals": {
+    "battles": 23,
+    "wins": 12,
+    "losses": 11,
+    "win_rate": 52.2,
+    "damage": 1145200,
+    "avg_damage": 49791,
+    "frags": 41,
+    "xp": 28411,
+    "planes_killed": 3,
+    "survival_rate": 47.8
+  },
+  "by_ship": [
+    {
+      "ship_id": 3761157328,
+      "ship_name": "Dalian",
+      "ship_tier": 9,
+      "ship_type": "Destroyer",
+      "battles": 6,
+      "wins": 4,
+      "win_rate": 66.7,
+      "damage": 287400,
+      "avg_damage": 47900,
+      "frags": 12,
+      "xp": 8203,
+      "planes_killed": 0,
+      "survived_battles": 3
+    }
+  ],
+  "by_day": [
+    {
+      "date": "2026-04-28",
+      "battles": 4,
+      "wins": 2,
+      "damage": 197200,
+      "frags": 7
+    }
+  ]
+}
+```
+
+Cached in Redis at `player:{realm}:{name}:battle-history:{days}`, TTL 5 min. Gated by `BATTLE_HISTORY_API_ENABLED` (default off) — when off the endpoint returns 404 so the absence is indistinguishable from a missing route.
+
+### Frontend (deferrable)
+
+- New `client/app/components/BattleHistoryCard.tsx`, mounted in `client/app/components/PlayerDetail.tsx` only when the response has `totals.battles > 0`.
+- Renders: top-line week summary, per-ship table sorted by battles, sparkline of `by_day` with damage / win-rate dual axis.
+- Reuses `client/app/lib/chartTheme.ts` palette + `client/app/lib/wrColor.ts` for the win-rate accent.
+
+If this tranche lands backend-only first, data accumulates while the frontend is in flight — no migration headache later.
+
+## Migration safety
+
+- One additive migration: `CreateModel('PlayerDailyShipStats')`. No `AlterField` on existing tables, no `NOT NULL` columns added.
+- Stacks on top of the PoC migration. If both tranches deploy together, the PoC migration runs first, then the rollout migration.
+- Cloud-DB-safe under the same logic as the PoC: the deployed code never references the new tables until the corresponding env flag flips, so applying the migration ahead of the code rollout is safe.
+- Backfill: management command `python manage.py rebuild_player_daily_ship_stats --since 2026-04-28` rebuilds rows from `BattleEvent`. No historical backfill is needed for the first week (events only exist from when capture turned on).
+- Rollback: drop `PlayerDailyShipStats` (single reverse migration). No FKs from existing tables point into it.
+
+## Rollout staging (gated, reversible)
+
+Each stage is gated by an independent env flag so the team can stop or roll back any individual step.
+
+1. **Capture-only.** Deploy the `record_observation_from_payloads` hook. Flip `BATTLE_HISTORY_CAPTURE_ENABLED=1` on the droplet. Observations + events accumulate; no UI yet. Watch for 2 days under real load to confirm that `BattleObservation` write volume matches expected refresh volume and that `BattleEvent` rows appear for known-active players.
+2. **Roll-up.** Deploy nightly task + on-write incremental + the new table migration. Flip `BATTLE_HISTORY_ROLLUP_ENABLED=1`. Watch the table grow; spot-check daily totals against `BattleEvent` aggregates with the validation queries below.
+3. **API + UI.** Flip `BATTLE_HISTORY_API_ENABLED=1` to expose `/api/player/.../battle-history`. Ship `BattleHistoryCard.tsx` in the same deploy or defer.
+4. **Pruning.** Enable `cleanup_old_battle_observations_task` after 14 days of data exist.
+
+Kill switch: unset any of the env flags. Tables remain (harmless).
+
+## Validation
+
+1. **Capture-only.** `BattleObservation.objects.filter(observed_at__gte=now-1h).count()` is in the hundreds (matches site refresh volume); `BattleEvent.objects.count()` grows when known-active players play.
+2. **Daily aggregation correctness.** For a sample player (e.g. lil_boots), assert:
+   ```sql
+   SELECT SUM(battles_delta), SUM(damage_delta) FROM warships_battleevent
+     WHERE player_id=? AND detected_at::date = '2026-04-28';
+   -- equals --
+   SELECT SUM(battles), SUM(damage) FROM warships_playerdailyshipstats
+     WHERE player_id=? AND date = '2026-04-28';
+   ```
+   Add this as a pytest covering the on-write incremental and the nightly sweeper independently.
+3. **Idempotency.** Re-running the nightly sweeper twice produces identical row counts and values (the `update_or_create` path is the only writer per `(player, date, ship_id)`).
+4. **Read latency.** `/api/player/lil_boots/battle-history?days=7` returns p95 < 50 ms warm cache, < 200 ms cold.
+5. **Backfill rebuild.** Drop a day's `PlayerDailyShipStats` rows for one player; run `rebuild_player_daily_ship_stats --since <day>`; confirm rows return to identical state.
+6. **Pruning safety.** `cleanup_old_battle_observations_task` with retention=14 days, run with `--dry-run` first; verify it does not touch `BattleEvent` rows.
+
+## WG API budget
+
+No new calls. Capture is a pure side-effect of fetches that already happen for `update_player_data` / `update_battle_data`. Rate budget is unchanged from the current site.
+
+The one cost is **storage and write amplification**: every refresh now writes a `BattleObservation` (~30–60 KB JSON). Mitigations:
+
+- 14-day retention on `BattleObservation`.
+- `ships_stats_json` only includes ships where `pvp.battles > 0` (4–8× shrink).
+- Postgres `jsonb` is already efficient; if size becomes a problem, a follow-on can compress to `bytea` + zstd.
+
+## Out of scope
+
+- Per-match-level resolution (the WG API has no per-match endpoint; multi-match collapse is acceptable).
+- Co-op / scenario / operations battles — only `pvp.battles` is tracked; non-PvP modes are silent.
+- Authenticated "log in to see _your_ history" — battlestats has no auth surface today; the read path is `/api/player/<name>/battle-history`, addressable to anyone who knows a name. Privacy is identical to the existing player-detail page.
+- Replacing the PoC's 60 s loop for `lil_boots` — the rollout coexists.
+
+## File map (touch list for the implementation tranche)
+
+| File                                                                     | Change                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/warships/incremental_battles.py`                                 | Add `record_observation_from_payloads`; refactor `record_observation_and_diff` to wrap it; add `_apply_event_to_daily_summary`. Widen `ships_stats_json` shape to include damage/xp/planes_killed/survived_battles. |
+| `server/warships/models.py`                                              | Add `PlayerDailyShipStats`.                                                                                                                                                                                         |
+| `server/warships/migrations/00XX_player_daily_ship_stats.py`             | Generated.                                                                                                                                                                                                          |
+| `server/warships/data.py:2365`                                           | Call `record_observation_from_payloads` at tail of `update_battle_data`, gated by `BATTLE_HISTORY_CAPTURE_ENABLED`. Failures logged and swallowed.                                                                  |
+| `server/warships/tasks.py`                                               | Add `roll_up_player_daily_ship_stats_task`, `cleanup_old_battle_observations_task`.                                                                                                                                 |
+| `server/warships/signals.py`                                             | Register nightly Beat schedules for both new tasks. Gate via env flags.                                                                                                                                             |
+| `server/warships/views.py`                                               | Add `@api_view` `battle_history` endpoint.                                                                                                                                                                          |
+| `server/warships/management/commands/rebuild_player_daily_ship_stats.py` | New.                                                                                                                                                                                                                |
+| `client/app/components/BattleHistoryCard.tsx`                            | New (deferrable).                                                                                                                                                                                                   |
+| `client/app/components/PlayerDetail.tsx`                                 | Mount `BattleHistoryCard` when totals.battles > 0 (deferrable).                                                                                                                                                     |
+| `client/app/lib/chartTheme.ts`, `client/app/lib/wrColor.ts`              | Reused as-is.                                                                                                                                                                                                       |
+| `CLAUDE.md` (env section)                                                | Document `BATTLE_HISTORY_CAPTURE_ENABLED`, `BATTLE_HISTORY_ROLLUP_ENABLED`, `BATTLE_HISTORY_API_ENABLED`, `BATTLE_OBSERVATION_RETENTION_DAYS`.                                                                      |
+
+## References
+
+- PoC runbook: `agents/runbooks/runbook-incremental-battle-poc-2026-04-27.md`.
+- Snapshot precedent for daily aggregates: `server/warships/data.py:2518` (`update_snapshot_data`) — same delta-from-previous-row pattern, but at player level.
+- Refresh path entry points: `server/warships/data.py:4696` (`update_player_data`), `:2365` (`update_battle_data`), `:199` (`refresh_player_detail_payloads`).
+- Incremental crawl path: `server/warships/management/commands/incremental_player_refresh.py:180` (calls `fetch_players_bulk` + `save_player`, then `refresh_player_detail_payloads`).
+- Visit-driven dispatch sites: `server/warships/views.py:143,254,261,268,295`.
+- Lock helper precedent: `server/warships/tasks.py:329` (`_run_locked_task`).
+
+## Next step
+
+User reviews this runbook. On approval, the implementation tranche begins — gated by the four `BATTLE_HISTORY_*` env flags so the deploy is a no-op until each stage is flipped on.

--- a/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
+++ b/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
@@ -283,6 +283,31 @@ Capture is automatic — it's a side-effect of the WG calls the site already mak
 
 **Optional accelerator for seeding.** If you want every active player observed within 24 h of flipping the capture flag, temporarily lower `PLAYER_REFRESH_INTERVAL_MINUTES` from `180` to `60` for one cycle. Triples observation rate, then revert. Existing infrastructure does the work — no new code, no new WG calls beyond what the existing crawl already issues.
 
+## Cadence guarantees (load contract)
+
+Two contracts the rollout is designed around. They're enforced by **existing** code, not a new throttle — call them out explicitly so a future engineer doesn't add a faster path that violates them.
+
+### Per-player capture: at most one observation every 15 minutes
+
+The capture hook lives at the **tail** of `update_battle_data` (`server/warships/data.py:~2450`), past the existing 15-min freshness early-bail at line 2382:
+
+```python
+if player.battles_json and player.battles_updated_at and datetime.now() - player.battles_updated_at < timedelta(minutes=15):
+    return player.battles_json   # capture hook NOT reached
+```
+
+Threshold is `PLAYER_BATTLE_DATA_STALE_AFTER = timedelta(minutes=15)` (`data.py:114`). Any visit-driven or crawl-driven call to `update_battle_data` within 15 min of the last refresh returns early without issuing a WG fetch and without firing the capture hook. **Visit storms on hot players are naturally throttled.**
+
+The user-facing manual refresh control on `PlayerDetail` mirrors this server-side throttle visually: red until 15 min has elapsed since the player's last fetch, green and clickable thereafter. Clicking issues a single forced refresh that passes through `update_battle_data`'s normal flow (still gated by the 15-min window if multiple users hit it at once on the same player).
+
+If a future change ever wants sub-15-min freshness for a specific user surface, the safe path is a separate code path that does **not** trigger `update_battle_data` — never lower the global `PLAYER_BATTLE_DATA_STALE_AFTER`.
+
+### Per-player coverage: daily differentials on every active player
+
+`incremental_player_refresh_task` walks the entire playerbase per realm in graduated tiers (`hot` / `active` / `warm`) on a ~3 h cycle. Hot players (visited in the last 12 h) cycle every ~10 min within the task; active players every ~1 h; warm players every cycle. Any player who's been seen by the site in the last 30 days is touched by the crawl at least 4–8 times per day, which means **at least 4–8 `BattleObservation` rows per active player per day** once capture is on — enough to compute meaningful daily differentials.
+
+The PoC's 60 s tracked-player loop continues to run for `lil_boots` and any other names in `BATTLE_TRACKING_PLAYER_NAMES` — that's a deliberate exception, scoped to a 1-row whitelist. Production droplet leaves `BATTLE_TRACKING_PLAYER_NAMES` empty, so the 15-min throttle is universal in prod.
+
 ## Operational watchpoints
 
 - **Storage growth** in `warships_battleobservation`. Pruning at day-14 is non-negotiable. Watch `pg_total_relation_size` daily during the first two weeks; if it overshoots the ~7 GB/realm envelope before pruning enables, narrow the per-ship JSON shape (`incremental_battles.py:_serialize_ships_payload`) first rather than disabling capture.

--- a/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
+++ b/agents/runbooks/runbook-battle-history-rollout-2026-04-28.md
@@ -21,13 +21,13 @@ Result: every player whose page is visited or whose tier rotates through the inc
 
 ## Dependencies
 
-This runbook is a follow-on to the PoC. Before the rollout tranche can land:
+This runbook is a follow-on to the PoC. The PoC tranche is built and verified locally — see `feature/incremental-battles-poc` (commit `d49600c`) — and lands as a separate PR ahead of this rollout. Specifically, by the time the rollout phases begin, the PoC commit will already provide:
 
-1. The PoC migration (`0051_battleobservation_battleevent.py` or equivalent) must be generated and applied. The PoC scaffolds `BattleObservation` and `BattleEvent` in `server/warships/models.py:436,473` but no migration exists yet.
-2. `server/warships/incremental_battles.py` must exist with `record_observation_and_diff(player_id, realm)`. It is referenced from `server/warships/tasks.py:1339` but the file is not in tree today.
-3. The PoC's `BattleObservation.ships_stats_json` shape must be widened (see "Storage shape" below) before any data is written, since the rollout's `BattleEvent.damage_delta` / `xp_delta` / `planes_killed_delta` / `survived` columns require it.
+1. Migrations `0051_battle_observation_event.py` (creates `BattleObservation` + `BattleEvent`) and `0052_battle_event_combat_metrics.py` (adds `damage_delta`, `xp_delta`, `planes_killed_delta`).
+2. `server/warships/incremental_battles.py` with `record_observation_and_diff(player_id, realm)`, `compute_battle_events`, and the per-ship `ShipSnapshot` shape that already includes `damage_dealt`, `xp`, `planes_killed`, and `survived_battles` — i.e. the wider `ships_stats_json` shape this runbook anticipates is already in tree on the PoC commit, no further widening required.
+3. `BATTLE_TRACKING_PLAYER_NAMES` env var support and the `poll-tracked-player-battles` Beat schedule (`server/warships/tasks.py` and `server/warships/signals.py`).
 
-The PoC's 60-second poll loop and `BATTLE_TRACKING_PLAYER_NAMES` env var stay intact. The rollout coexists with it; they share the same orchestrator function.
+The PoC's 60-second poll loop and `BATTLE_TRACKING_PLAYER_NAMES` env var stay intact through the rollout. The rollout coexists with the PoC; they share the same orchestrator function (`record_observation_from_payloads`, introduced in Phase 1 of the rollout as a refactor of the PoC's `record_observation_and_diff`).
 
 ## Design
 
@@ -61,28 +61,14 @@ The hook never raises into the refresh path: failures are logged and swallowed s
 
 ### Storage shape
 
-#### Widened observation (modifies the PoC schema before any data lands)
+#### Per-ship observation shape (already in tree on the PoC commit)
 
-The PoC's `ships_stats_json` was specced as compact `{ship_id: {battles, wins, losses, frags}}`. To support the rollout's full delta vocabulary, **before the PoC migration lands** widen the per-ship JSON shape to:
+The PoC commit already writes `BattleObservation.ships_stats_json` as a list of dicts with the full delta vocabulary the rollout needs — `battles`, `wins`, `losses`, `frags`, `damage_dealt`, `xp`, `planes_killed`, `survived_battles` per ship. See `server/warships/incremental_battles.py:_coerce_ship_snapshot` and `record_observation_and_diff`. No further shape widening is required for the rollout phases.
 
-```json
-{
-  "<ship_id>": {
-    "battles": int,
-    "wins": int,
-    "losses": int,
-    "frags": int,
-    "damage_dealt": int,
-    "original_xp": int,
-    "planes_killed": int,
-    "survived_battles": int
-  }
-}
-```
+Two open optimizations remain (deferable, not blocking):
 
-Stored only for ships where `pvp.battles > 0`. Most accounts have touched <100 of the ~548 ships in the game, so this filter cuts the JSON 4–8× vs. storing every ship.
-
-No DB migration is required for this change — `ships_stats_json` is already a `JSONField`. The PoC orchestrator just writes a richer dict.
+1. **Restrict to active ships.** Today every ship returned by `ships/stats/` is captured. Most accounts have touched <100 of the ~548 ships in the game; filtering to `pvp.battles > 0` would cut the JSON 4–8×. Land in Phase 7 or earlier if storage growth in Phase 2 exceeds the envelope.
+2. **Compression of stale rows.** `BattleObservation` rows older than the active diff window (only the most recent observation per player is read by `compute_battle_events`) could be compressed or have their `ships_stats_json` nulled out once the corresponding `BattleEvent` rows exist. Phase 7 territory; see "Compression / shape work" at the bottom of this runbook.
 
 #### New table: `PlayerDailyShipStats`
 

--- a/agents/runbooks/runbook-incremental-battle-poc-2026-04-27.md
+++ b/agents/runbooks/runbook-incremental-battle-poc-2026-04-27.md
@@ -1,0 +1,181 @@
+# Runbook: Incremental Battle Capture PoC (lil_boots)
+
+_Created: 2026-04-27_
+_Context: Prove out per-battle delta capture for a single tracked player (`lil_boots`) by frequently polling WG aggregate stats and diffing successive observations. Side-channel PoC, additive-only schema, gated off in production._
+_Status: Design approved (Ultraplan, 2026-04-27). Implementation not started._
+
+## Purpose
+
+Battlestats today refreshes player stats on a 3-hour incremental cycle and surfaces only running totals. This PoC tests a tighter loop: poll the WG API every ~60 seconds for `lil_boots`, detect when running totals advance, compute the per-ship delta, and show it on the player page as a "latest battle" card. Validation is human-in-the-loop — the user plays one PvP match, then refreshes the page and verifies that the card shows the right ship and W/L outcome within ~2 minutes.
+
+The PoC must run **alongside the live site without disturbing it**: prod on DigitalOcean must be safe to deploy without picking up the new schedule, and any DB migration applied locally must remain safe for the deployed prod release. All new behavior is gated by a single env var (`BATTLE_TRACKING_PLAYER_NAMES`); when unset, the system is byte-for-byte identical to today.
+
+## Premise: WG has no per-match endpoint
+
+The Wargaming public API exposes only aggregate running totals — `account/info/` (player) and `ships/stats/` (per-ship). There is no per-match feed. Per-battle deltas must therefore be **computed by diffing successive snapshots** of those aggregates. This makes the PoC a pure pull-and-diff exercise:
+
+- Observation = a single successful poll of both endpoints.
+- Event = a detected positive delta in `pvp_battles` between two observations, attributed to the ship whose per-ship `pvp.battles` advanced.
+
+Durability comes from snapshot persistence and idempotent diffing, not transactional ingest. A failed poll writes nothing and the next tick retries; deltas are tolerant of arbitrary gaps between successful observations.
+
+## Design
+
+### Data model (additive only)
+
+Two new tables in `server/warships/models.py`. **No changes** to `Player`, `Snapshot`, or `PlayerExplorerSummary`.
+
+**`BattleObservation`** — one row per successful poll.
+
+| Field | Type | Notes |
+|---|---|---|
+| `player` | FK → Player | indexed |
+| `observed_at` | DateTimeField | server-side timestamp of the poll |
+| `pvp_battles` | IntegerField | from `account/info/.statistics.pvp.battles` |
+| `pvp_wins` | IntegerField | |
+| `pvp_losses` | IntegerField | |
+| `pvp_frags` | IntegerField | |
+| `pvp_survived_battles` | IntegerField | |
+| `last_battle_time` | DateTimeField, null | from WG payload |
+| `ships_stats_json` | JSONField | compact `{ship_id: {battles, wins, losses, frags}}` |
+| `source` | CharField | `"poll"` or `"manual"` |
+
+Indexes: `(player, observed_at desc)`. `unique_together (player, observed_at)`.
+
+**`BattleEvent`** — one row per detected battle.
+
+| Field | Type | Notes |
+|---|---|---|
+| `player` | FK → Player | |
+| `detected_at` | DateTimeField | when diff was computed |
+| `ship_id` | BigIntegerField | |
+| `ship_name` | CharField | denormalized for display |
+| `battles_delta` | IntegerField | usually 1; >1 when multiple matches between polls |
+| `wins_delta` | IntegerField | |
+| `losses_delta` | IntegerField | |
+| `frags_delta` | IntegerField | |
+| `survived` | BooleanField, null | inferred from `survived_battles` delta |
+| `from_observation` | FK → BattleObservation | |
+| `to_observation` | FK → BattleObservation | |
+
+Dedup key: `(from_observation, to_observation, ship_id)` unique.
+
+### Capture pipeline
+
+New Celery task in `server/warships/tasks.py`:
+
+```
+poll_tracked_player_battles_task(player_id)
+```
+
+- Queue: `background`.
+- Reuses the WG client at `server/warships/api/client.py:35` (already retries 429/5xx with backoff).
+- Wrapped in the existing `_run_locked_task` Redis-lock helper (`tasks.py:329`), keyed `warships:tasks:poll_tracked_player_battles:{player_id}:lock`, **5-min timeout** (shorter than the default 15 min so we don't lock out the next tick).
+- Steps:
+  1. Fetch `account/info/` and `ships/stats/`.
+  2. If both succeed, `BattleObservation.objects.create(...)`.
+  3. Load the previous observation for this player.
+  4. If `current.pvp_battles > previous.pvp_battles`, walk per-ship deltas and create one `BattleEvent` per ship whose battle count advanced.
+- Idempotency: re-running on identical WG state inserts a fresh observation row but produces no new events because the delta is computed from the immediately-prior row, which already reflects the same totals.
+
+New Celery Beat schedule registered in `server/warships/signals.py`:
+
+```
+poll-tracked-player-battles  →  every 60s (configurable)
+```
+
+The schedule wakes once per minute, reads `BATTLE_TRACKING_PLAYER_NAMES` from env, resolves each name to a `Player`, and dispatches one `poll_tracked_player_battles_task` per resolved id. **If the env var is empty/unset, the wake-up is a no-op.** This is the same gating pattern as `HOT_ENTITY_PINNED_PLAYER_NAMES`.
+
+### Frontend surfacing
+
+Backend: extend the existing `/api/player/{playerName}/` payload (assembled in `server/warships/views.py` / `server/warships/data.py`) with an optional `latest_battle` block:
+
+```json
+{
+  "ship_name": "Yamato",
+  "ship_tier": 10,
+  "frags_delta": 2,
+  "won": true,
+  "observed_at": "2026-04-27T18:14:02Z",
+  "observation_lag_seconds": 47
+}
+```
+
+Absent for non-tracked players → contract is purely additive.
+
+Frontend: new `client/app/components/LatestBattleCard.tsx`, mounted at the top of `PlayerDetail.tsx` only when `latest_battle` is present. Styling reuses `client/app/lib/chartTheme.ts` and `client/app/lib/wrColor.ts` for the win/loss accent.
+
+### Migration safety
+
+- `python manage.py makemigrations warships` produces e.g. `0067_battleobservation_battleevent.py` — two `CreateModel` operations, no `AlterField` on existing tables, no `NOT NULL` columns added to existing tables.
+- **Cloud-DB safety:** because the migration is additive only, applying it locally against the cloud DB does not break the deployed prod release — prod's running code never references the new tables. The `migrate --noinput` step in `server/deploy/deploy_to_droplet.sh:437` is a no-op once the tables exist.
+- **Rollback:** a single reverse migration (`DROP TABLE` for both) is sufficient. Both tables are PoC-only with no FKs pointing into them from existing code.
+
+### Durability against WG flakiness
+
+- WG client retry policy (`api/client.py:35`) handles 429/5xx with backoff — no change needed.
+- A failed poll writes nothing — no partial observation. Next tick (60s later) retries.
+- Deltas are computed from any two successful observations, not a continuous chain. Arbitrary gaps are tolerated.
+- If WG returns stale data (totals unchanged across many polls), no event is emitted — correct behavior.
+- Per-player rate: 2 WG calls/min for one account, well under the per-key rate cap.
+- Observations older than 7 days are pruned by lazy-adding a sweep to an existing periodic cleanup task in `tasks.py` (prevents unbounded growth; not implemented in the initial PoC if storage stays small).
+
+### Kill switch
+
+1. Unset `BATTLE_TRACKING_PLAYER_NAMES` (or remove from env) → next Beat tick the schedule short-circuits with no work dispatched.
+2. Or comment out the Beat registration in `server/warships/signals.py` and restart workers.
+3. Tables remain (harmless, empty for non-tracked players).
+
+## Validation plan
+
+1. Apply migration locally: `cd server && python manage.py migrate`.
+2. Set `BATTLE_TRACKING_PLAYER_NAMES=lil_boots` in local env; restart Celery beat + the `background` worker.
+3. Confirm baseline:
+   ```
+   python manage.py shell -c "from warships.models import BattleObservation; print(BattleObservation.objects.count())"
+   ```
+   Count increments at ~1/min.
+4. **User plays one PvP game in WoWS.**
+5. Within ~2 min after the post-battle results screen, a `BattleEvent` row should appear; the player page should show the `LatestBattleCard` with the correct ship and W/L outcome.
+6. Sanity checks:
+   - `BattleEvent.battles_delta == 1` for a single match (or `>1` if multiple games happened between polls — acceptable; card shows the most recent ship).
+   - `observation_lag_seconds` on the card matches `now − latest BattleObservation.observed_at`.
+   - Page refresh shows the same battle, no flicker, no duplicate event row.
+7. Failure-mode probe: stop local Redis briefly (~30s); confirm the task logs the lock failure and recovers on the next tick without writing a duplicate observation.
+
+## Out of scope for this PoC
+
+- Multi-player tracking, public rollout, opt-in UX.
+- A per-match endpoint (none exists in WG).
+- Historical backfill (forward-looking only — first observation defines the baseline).
+- Any modification to `Snapshot`, `PlayerExplorerSummary`, daily aggregates, or the existing 3-hour refresh path.
+- Production deployment of the schedule. Prod env stays unset.
+
+## File map (touch list for implementation tranche)
+
+| File | Change |
+|---|---|
+| `server/warships/models.py` | Add `BattleObservation`, `BattleEvent` |
+| `server/warships/migrations/00XX_battleobservation_battleevent.py` | Generated |
+| `server/warships/tasks.py` | Add `poll_tracked_player_battles_task`; reuse `_run_locked_task` (line 329) |
+| `server/warships/signals.py` | Register `poll-tracked-player-battles` Beat schedule, gated on `BATTLE_TRACKING_PLAYER_NAMES` |
+| `server/warships/api/players.py` | Reused as-is (line 25 — `account/info/` fetcher) |
+| `server/warships/api/ships.py` | Reused as-is (line 231 — `ships/stats/` fetcher) |
+| `server/warships/api/client.py` | Reused as-is (line 35 — retry policy) |
+| `server/warships/data.py` | Extend player API payload with optional `latest_battle` block |
+| `server/warships/views.py` | Wire `latest_battle` through the player detail view |
+| `client/app/components/LatestBattleCard.tsx` | New |
+| `client/app/components/PlayerDetail.tsx` | Conditionally mount `LatestBattleCard` |
+| `client/app/lib/chartTheme.ts`, `client/app/lib/wrColor.ts` | Reused as-is for styling |
+| `CLAUDE.md` (env section) | Document `BATTLE_TRACKING_PLAYER_NAMES` |
+
+## References
+
+- Existing single-player refresh tasks (template for the new task): `server/warships/tasks.py:524,549,593`.
+- Delta-from-previous-row precedent: `update_snapshot_data` at `server/warships/data.py:2518`.
+- Deploy migrate step (proves additive migration is prod-safe): `server/deploy/deploy_to_droplet.sh:437`.
+- Player models touched/untouched: `server/warships/models.py:15` (Player), `:160` (Snapshot), `:179` (PlayerExplorerSummary).
+
+## Next step
+
+User plays a game, then we iterate on the runbook (or kick off the implementation tranche) based on what the validation surfaces.


### PR DESCRIPTION
Design doc for taking the incremental-battle PoC playerbase-wide as a longitudinal per-ship per-day battle history. Implementation lands separately.