### PR TITLE
Refactor follow-ups: heatmap consolidation + SQLite USE_TZ test fix

### DIFF
--- a/client/app/components/RankedWRBattlesHeatmapSVG.tsx
+++ b/client/app/components/RankedWRBattlesHeatmapSVG.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import wrColor from '../lib/wrColor';
 import * as d3 from 'd3';
 import { PLAYER_ROUTE_PANEL_FETCH_TTL_MS } from '../lib/playerRouteFetch';
 import { fetchSharedJson } from '../lib/sharedJsonFetch';
@@ -47,16 +48,6 @@ interface RankedWRBattlesPayload {
     player_point?: CorrelationPoint | null;
 }
 
-const selectColorByWR = (winRate: number): string => {
-    if (winRate > 65) return '#810c9e';
-    if (winRate >= 60) return '#D042F3';
-    if (winRate >= 56) return '#3182bd';
-    if (winRate >= 54) return '#74c476';
-    if (winRate >= 52) return '#a1d99b';
-    if (winRate >= 50) return '#fed976';
-    if (winRate >= 45) return '#fd8d3c';
-    return '#a50f15';
-};
 
 type Colors = typeof chartColors['light'];
 
@@ -169,7 +160,7 @@ const drawChart = (containerElement: HTMLDivElement, payload: RankedWRBattlesPay
             .attr('cx', x(clampedX))
             .attr('cy', y(clampedY))
             .attr('r', 8)
-            .attr('fill', selectColorByWR(point.y))
+            .attr('fill', wrColor(point.y))
             .attr('fill-opacity', 0.95)
             .attr('stroke', colors.barStroke)
             .attr('stroke-width', 2);
@@ -239,7 +230,7 @@ const drawChart = (containerElement: HTMLDivElement, payload: RankedWRBattlesPay
             .attr('x', summaryX)
             .style('font-size', axisFontSize)
             .style('font-weight', '600')
-            .style('fill', selectColorByWR(payload.player_point.y))
+            .style('fill', wrColor(payload.player_point.y))
             .text(`${Math.round(payload.player_point.x).toLocaleString()} games @ ${payload.player_point.y.toFixed(1)}%`);
     } else {
         summary.append('text')

--- a/server/warships/tests/test_incremental_battles.py
+++ b/server/warships/tests/test_incremental_battles.py
@@ -1410,9 +1410,10 @@ class RebuildDailyShipStatsTests(TestCase):
         self.obs_c = BattleObservation.objects.create(
             player=self.player, pvp_battles=102,
         )
-        midday = django_timezone.make_aware(
-            datetime(2026, 4, 28, 12, 0, 0),
-        )
+        # USE_TZ=False project — pass naive datetimes; the SQLite adapter
+        # rejects tz-aware values (which a stray make_aware() wrapper used
+        # to silently produce, breaking the test under SQLite).
+        midday = datetime(2026, 4, 28, 12, 0, 0)
         BattleEvent.objects.create(
             player=self.player, ship_id=42, ship_name="Yamato",
             battles_delta=1, wins_delta=1, frags_delta=2,
@@ -2252,8 +2253,8 @@ class PeriodRollupsTests(TestCase):
             battles=3, wins=2, losses=1, frags=5,
             damage=180_000, xp=4_500, planes_killed=0,
             survived_battles=1,
-            first_event_at=django_timezone.make_aware(datetime(2026, 4, 27, 12, 0)),
-            last_event_at=django_timezone.make_aware(datetime(2026, 4, 27, 18, 0)),
+            first_event_at=datetime(2026, 4, 27, 12, 0),
+            last_event_at=datetime(2026, 4, 27, 18, 0),
         )
         PlayerDailyShipStats.objects.create(
             player=self.player, date=self.day_b, ship_id=42,
@@ -2261,8 +2262,8 @@ class PeriodRollupsTests(TestCase):
             battles=4, wins=3, losses=1, frags=7,
             damage=240_000, xp=6_200, planes_killed=0,
             survived_battles=2,
-            first_event_at=django_timezone.make_aware(datetime(2026, 4, 30, 9, 0)),
-            last_event_at=django_timezone.make_aware(datetime(2026, 4, 30, 21, 0)),
+            first_event_at=datetime(2026, 4, 30, 9, 0),
+            last_event_at=datetime(2026, 4, 30, 21, 0),
         )
 
     def test_rebuild_period_rollups_writes_weekly_monthly_yearly(self):


### PR DESCRIPTION
## Summary

Two small follow-up tranches stacked on top of PR #5
(`refactor/near-final-form-cleanup-2026-05-03`). Each is its own commit.

| Commit | What | Lines |
|---|---|---|
| `86897be` | refactor(client): RankedWRBattlesHeatmap selectColorByWR → wrColor | +3 / -12 |
| `e113657` | test(incremental_battles): fix SQLite USE_TZ failures in 6 tests | +8 / -7 |

## Tranche A — RankedWRBattlesHeatmap consolidation

Continues the inline-`selectColorByWR` cleanup from PR #5. Substitutes
the byte-identical inline copy with the canonical `wrColor()` helper.

**Intentionally NOT touched**: `TierTypeHeatmapSVG.tsx` uses
DECIMAL-FRACTION inputs (winRatio in [0,1] not [0,100]) AND has an extra
`>= 0.40 → '#e6550d'` color band not present in `wrColor()`. A literal
substitution would silently re-band 4–5% of cells. Needs a unit
adapter + extra band in `wrColor()` to be safely consolidated; out of
scope here.

## Tranche B — SQLite USE_TZ test fix

The project runs `USE_TZ=False` everywhere (`server/battlestats/settings.py:122`),
so naive datetimes are the canonical form. `RebuildDailyShipStatsTests`
and `PeriodRollupsTests` wrapped fixture datetimes in
`django_timezone.make_aware(...)`, producing tz-aware values that
SQLite rejected — 6 tests have been red under SQLite for weeks
(passed under Postgres which has a richer adapter).

After fix: `warships/tests/test_incremental_battles.py` is **105/105** under
SQLite (was 99/105).

## Test plan

- [x] Frontend lint clean + 95/95 tests + production build green
- [x] Backend lean release gate green (242/242)
- [x] Full `test_incremental_battles.py` green (105/105 — was 99/105)

## Base / merge order

Stacked on `refactor/near-final-form-cleanup-2026-05-03` (PR #5). Merge
PR #5 first, then this rebases trivially onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)