### PR TITLE
chore: stripe per-realm schedules + promote BattleObservation floor to 6-hourly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,12 @@ Resilience mechanisms:
 - **Consumer watchdog** — systemd timer (`battlestats-celery-watchdog.timer`) checks consumer counts every 5 min via `rabbitmqctl list_queues` and restarts zombie workers (process alive, 0 consumers)
 - **Soft systemd dependencies** — service units use `Wants=` (not `Requires=`) for Redis/RabbitMQ to prevent cascading stops during dependency restarts
 
+### Per-realm schedule striping
+
+Periodic tasks that run per realm (NA, EU, ASIA) are striped via `REALM_INTERVAL_OFFSETS = {'na': 0, 'eu': 1, 'asia': 2}` in `signals.py` so at most one realm is mid-cycle at any moment on the `background` worker. Striped families: landing/recent-players/distribution/correlation/hot-entity/recently-viewed warmers, incremental player refresh, incremental ranked refresh, and the rolling BattleObservation floor. The `_realm_crontab_for_cycle(realm, cycle_minutes, base_minute=0)` helper computes per-realm crontab `(minute_str, hour_str)` from the cycle length and offset index. Daily-cron families that already had hour offsets (clan crawl, clan-tier-dist warmer, best-player snapshot) continue to use `REALM_CRAWL_CRON_HOURS = {'eu': 0, 'na': 6, 'asia': 12}`.
+
+Battle pickup latency: the rolling 6-hourly observation floor (active-7d players whose latest observation > `BATTLE_OBSERVATION_FLOOR_HOURS` = 8h) guarantees no active player goes >8h without a fresh `BattleObservation`, regardless of whether the tiered crawler reached them. Combined with the page-load 15-min staleness check on visited players, the worst-case "battle landed in DB" lag for any active player on any realm is roughly 8h.
+
 ### Nginx / HTTP
 
 - **HTTP/2** enabled on the production nginx 443 listeners. Eliminates the browser's 6-connection-per-origin limit under HTTP/1.1, allowing all concurrent chart and hydration requests to proceed without slot contention.
@@ -284,11 +290,13 @@ Releases are cut manually with `./scripts/release.sh <patch|minor|major>`, which
 - `ENABLE_CRAWLER_SCHEDULES` — Master kill switch for the daily clan crawl, clan-crawl watchdog, incremental player refresh, and incremental ranked refresh schedules (set `1` in production)
 - `CLAN_CRAWL_SCHEDULE_HOUR` / `CLAN_CRAWL_SCHEDULE_MINUTE` — Base UTC hour/minute for the daily clan crawl cron; per-realm offsets come from `REALM_CRAWL_CRON_HOURS` in `signals.py` (defaults: hour=`3`, minute=`0`)
 - `CLAN_CRAWL_WATCHDOG_MINUTES` — Clan crawl watchdog poll interval in minutes (default: `5`)
-- `PLAYER_REFRESH_INTERVAL_MINUTES` — Incremental player refresh cadence per realm (default: `180`). Each cycle walks the graduated hot/active/warm tiers and takes ~35-78 min/realm at steady state, so the safe minimum is `cycle_time × num_realms / num_slots`.
+- `PLAYER_REFRESH_INTERVAL_MINUTES` — Incremental player refresh cycle length in minutes per realm (default: `180`). Realms are striped via `REALM_INTERVAL_OFFSETS` so NA fires at minute 0 of hours `0,3,6,9,12,15,18,21`, EU at `1,4,7,…`, ASIA at `2,5,8,…`. Each cycle walks the graduated hot/active/warm tiers and takes ~35-78 min/realm at steady state.
 - `PLAYER_REFRESH_HOT_STALE_HOURS` — Hot-tier staleness threshold for incremental player refresh (default: `12`). Players whose `last_lookup` is within this window are visited every cycle.
 - `PLAYER_REFRESH_ACTIVE_STALE_HOURS` — Active-tier staleness threshold (default: `24`).
 - `PLAYER_REFRESH_WARM_STALE_HOURS` — Warm-tier staleness threshold (default: `72`). Outside this window players drop to occasional refreshes.
-- `RANKED_REFRESH_INTERVAL_MINUTES` — Incremental ranked refresh cadence per realm (default: `120`)
+- `RANKED_REFRESH_INTERVAL_MINUTES` — Incremental ranked refresh cycle length in minutes per realm (default: `120`). Striped per realm via `REALM_INTERVAL_OFFSETS` (40-min stride) so NA, EU, and ASIA never fire concurrently.
+- `BATTLE_OBSERVATION_FLOOR_HOUR` / `BATTLE_OBSERVATION_FLOOR_MINUTE` — Base UTC hour/minute for the rolling 6-hourly BattleObservation floor (defaults: `1` / `15`). Each realm fires 4×/day with a 2h stride: NA at base, EU at base+2h, ASIA at base+4h.
+- `BATTLE_OBSERVATION_FLOOR_HOURS` — Active-7d staleness threshold for the floor sweep (default: `8`, tightened from `22h` on 2026-05-09 alongside the cadence promotion). Active players whose latest observation is older than this get a fresh fetch.
 - `CELERY_BROKER_HEARTBEAT` — amqp heartbeat in seconds; `0` disables (default: `0`). The default 60s heartbeat is starved by long-running tasks (`incremental_player_refresh_task`), causing `BrokenPipeError on stopping Hub` and systemd worker restarts. We rely on TCP keepalive instead.
 - `ANALYTICAL_WORK_MEM` — Per-query `work_mem` for analytical queries (default: `8MB`)
 - `RECENTLY_VIEWED_PLAYER_LIMIT` — Max recently-viewed players to warm (default: 10)

--- a/agents/runbooks/runbook-battle-observation-floor-2026-05-02.md
+++ b/agents/runbooks/runbook-battle-observation-floor-2026-05-02.md
@@ -118,3 +118,15 @@ Should return ≤0 rows shortly after the daily floor task completes (with the n
 - Replacing the tiered crawler — different responsibilities. Tiered crawler keeps hot players warm at 12h cadence. Floor task guarantees nobody falls past 24h. They cooperate.
 - Sub-hour resolution for hot players — not needed; the on-render refresh path (`queue_ranked_observation_refresh` in `tasks.py`) already covers visit-driven freshness with a 5-min staleness gate.
 - Backfilling historical gaps — out of scope for the floor task. The diff lane attributes the gap activity to the next-observed date and the user can read the spike for what it is.
+
+## Update 2026-05-09 — Promotion to rolling 6-hourly floor
+
+The original `daily-observation-floor-{realm}` schedule fired once per day per realm at `01:15 + REALM_CRAWL_CRON_HOURS[realm]` UTC with `BATTLE_OBSERVATION_FLOOR_HOURS=22`. As of 2026-05-09 this is replaced with a rolling 6-hourly floor:
+
+- Schedule renamed to `observation-floor-{realm}` (the legacy `daily-` name is in `_RETIRED_SCHEDULE_NAMES` so old rows are pruned).
+- Per-realm stripe via `REALM_INTERVAL_OFFSETS` with a 2h stride: NA fires at `BATTLE_OBSERVATION_FLOOR_HOUR` (default 1) UTC and every 6h thereafter, EU at base+2h, ASIA at base+4h, each at `BATTLE_OBSERVATION_FLOOR_MINUTE` (default 15).
+- `BATTLE_OBSERVATION_FLOOR_HOURS` default tightened from 22 → 8.
+- Worst-case "battle landed in DB" lag for any active-7d player is now ~8h (down from ~24h).
+- Per-cycle candidate count drops because the tightened staleness threshold is also a tighter window — most cycles return <100 candidates instead of the original ~200-500/day budget. The active-7d population is unchanged, so total daily WG-call volume is comparable.
+
+The single command + `ensure_daily_battle_observations_task` body is unchanged — the 8h default lives in the management command's `DEFAULT_STALE_HOURS`. CLI overrides (`--stale-hours 22`) continue to work for manual ops.

--- a/agents/runbooks/runbook-periodic-task-topology-2026-04-11.md
+++ b/agents/runbooks/runbook-periodic-task-topology-2026-04-11.md
@@ -462,3 +462,15 @@ Per CLAUDE.md "Runbook reconciliation": this runbook is the authoritative descri
 - Any of the `ENABLE_CRAWLER_SCHEDULES` / `CLAN_CRAWL_*` / `PLAYER_REFRESH_INTERVAL_MINUTES` / `RANKED_REFRESH_INTERVAL_MINUTES` env vars
 
 When superseded by a broader refactor, move to `agents/runbooks/archive/`.
+
+---
+
+## Update 2026-05-09 — Per-realm striping + rolling observation floor
+
+Two changes to the topology, both inside `signals.py`. No new tasks, no migrations:
+
+1. **Per-realm interval schedules are now crontab-striped.** The `IntervalSchedule(every=N)` rows that fired all 3 realms in lockstep on every tick have been replaced with `CrontabSchedule` rows striped via a new `REALM_INTERVAL_OFFSETS = {'na': 0, 'eu': 1, 'asia': 2}` map. The new `_realm_crontab_for_cycle(realm, cycle_minutes, base_minute=0)` helper translates `(realm, cycle_minutes)` into `(minute_str, hour_str)` so each realm's stripe sits inside the cycle without overlap. Affected families: `landing-page-warmer`, `recent-players-warmer`, `player-distribution-warmer`, `player-correlation-warmer`, `hot-entity-cache-warmer`, `recently-viewed-player-warmer`, `incremental-player-refresh`, `incremental-ranked-refresh`. With cycle=180 the player refresh fires NA at hours `0,3,6,…,21`, EU at `1,4,7,…,22`, ASIA at `2,5,8,…,23`, all at minute 0. The serialising `cache.add` realm lock still acts as a safety net.
+
+2. **Daily observation floor → rolling 6-hourly floor.** `daily-observation-floor-{realm}` was renamed to `observation-floor-{realm}` and promoted to fire 4× per day per realm with a 2h stride (NA at base, EU at base+2h, ASIA at base+4h). `BATTLE_OBSERVATION_FLOOR_HOURS` default tightened from 22h → 8h alongside the cadence change. The legacy `daily-observation-floor-{realm}` rows are added to `_RETIRED_SCHEDULE_NAMES` so they get pruned on next post_migrate.
+
+The active schedule reference list above is now stale — see `signals.py` for the current set; the canonical inventory is mirrored in `CLAUDE.md` under "Per-realm schedule striping". Cycle-time analysis from this runbook (35-78 min wall clock per realm refresh) still holds — striping smooths the load curve but doesn't change per-cycle cost. Test coverage now lives in `server/warships/tests/test_periodic_schedule_topology.py` (12 tests covering registration, crontab vs interval, offset distinctness, observation floor cadence, and retirement pruning).

--- a/server/deploy/deploy_to_droplet.sh
+++ b/server/deploy/deploy_to_droplet.sh
@@ -173,6 +173,16 @@ else
   echo 'BATTLE_HISTORY_RANKED_CAPTURE_REALMS=na,eu,asia' >> /etc/battlestats-server.env
 fi
 
+# Pin the rolling-6h BattleObservation floor staleness threshold to 8h
+# (tightened from 22h on 2026-05-09 alongside the cadence promotion).
+# Code defaults to 8h too; setting it explicitly here makes the live
+# value visible and overrideable without a redeploy.
+if grep -q '^BATTLE_OBSERVATION_FLOOR_HOURS=' /etc/battlestats-server.env; then
+  sed -i 's|^BATTLE_OBSERVATION_FLOOR_HOURS=.*|BATTLE_OBSERVATION_FLOOR_HOURS=8|' /etc/battlestats-server.env
+else
+  echo 'BATTLE_OBSERVATION_FLOOR_HOURS=8' >> /etc/battlestats-server.env
+fi
+
 get_env_value() {
   local key="$1"
   local raw

--- a/server/warships/management/commands/ensure_daily_battle_observations.py
+++ b/server/warships/management/commands/ensure_daily_battle_observations.py
@@ -8,18 +8,18 @@ command targets that gap directly.
 
 Walks active visible players in `--realm` whose `last_battle_date` is
 within `--days` (default 7) and whose most recent `BattleObservation`
-is older than `--stale-hours` (default 22, leaving ~2h of slack vs.
-the 24h floor target). For each candidate, dispatches a fresh WG
-fetch + observation via `record_observation_and_diff`, OR
-`record_ranked_observation_and_diff` when ranked capture is on for
-the realm.
+is older than `--stale-hours` (default 8, tightened from 22h alongside
+the 2026-05-09 promotion to a 6-hourly Beat schedule). For each
+candidate, dispatches a fresh WG fetch + observation via
+`record_observation_and_diff`, OR `record_ranked_observation_and_diff`
+when ranked capture is on for the realm.
 
 Usage (manual):
     python manage.py ensure_daily_battle_observations --realm na --dry-run
     python manage.py ensure_daily_battle_observations --realm na
     python manage.py ensure_daily_battle_observations --realm na --stale-hours 12 --limit 500
 
-Beat-scheduled daily by `signals.py` so the floor is automatic.
+Beat-scheduled every 6h per realm by `signals.py` so the floor is automatic.
 """
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ from warships.models import BattleObservation, DEFAULT_REALM, Player, VALID_REAL
 log = logging.getLogger("battle_observation_floor")
 
 DEFAULT_DAYS = 7
-DEFAULT_STALE_HOURS = 22
+DEFAULT_STALE_HOURS = 8
 DEFAULT_LIMIT = 3000
 DEFAULT_DELAY = 0.3
 

--- a/server/warships/signals.py
+++ b/server/warships/signals.py
@@ -8,8 +8,50 @@ from django.dispatch import receiver
 
 from warships.models import VALID_REALMS
 
-# Per-realm cron hour offsets for staggering heavy tasks.
+# Per-realm cron hour offsets for staggering heavy daily tasks.
 REALM_CRAWL_CRON_HOURS = {'eu': 0, 'na': 6, 'asia': 12}
+
+# Per-realm minute-offset *index* used to stripe interval-style schedules
+# across a common cycle so at most one realm is mid-cycle at any moment
+# on the background worker. The actual stride within a cycle is
+# `cycle_minutes // len(REALM_INTERVAL_OFFSETS)` (e.g. 60min for a 180min
+# cycle, 40min for 120min, 10min for 30min). See
+# `_realm_crontab_for_cycle` below.
+REALM_INTERVAL_OFFSETS = {'na': 0, 'eu': 1, 'asia': 2}
+
+
+def _realm_crontab_for_cycle(
+    realm: str, cycle_minutes: int, base_minute: int = 0
+) -> tuple[str, str]:
+    """Return ``(minute_str, hour_str)`` for a striped per-realm crontab.
+
+    Each realm's task fires every ``cycle_minutes`` starting at
+    ``base_minute + offset_index * stride`` minutes-of-day, where
+    ``stride = cycle_minutes // num_realms``. The returned strings are
+    already in crontab list form (e.g. ``"0,30"`` or ``"0,3,6,9,12,15,18,21"``)
+    or the wildcard ``"*"`` when every minute / hour is covered.
+
+    Works for cycles that divide 60 (10, 30) or are multiples of an hour
+    aligned with 1440 (60, 120, 180, 360, 720). Other values are rounded
+    down at the stride and may produce a slightly off-pattern stripe.
+    """
+    realm_count = max(len(REALM_INTERVAL_OFFSETS), 1)
+    stride = max(cycle_minutes // realm_count, 1)
+    offset_idx = REALM_INTERVAL_OFFSETS.get(realm, 0)
+    start_minute_of_day = (base_minute + offset_idx * stride) % 1440
+
+    fire_times = []
+    t = start_minute_of_day
+    while t < 1440:
+        fire_times.append(t)
+        t += cycle_minutes
+
+    minutes = sorted({t % 60 for t in fire_times})
+    hours = sorted({t // 60 for t in fire_times})
+
+    minute_str = '*' if len(minutes) == 60 else ','.join(str(m) for m in minutes)
+    hour_str = '*' if len(hours) == 24 else ','.join(str(h) for h in hours)
+    return minute_str, hour_str
 
 
 def _configured_clan_battle_warm_ids():
@@ -68,6 +110,13 @@ _RETIRED_SCHEDULE_NAMES = [
     "landing-random-clan-queue-refill-na",
     "landing-random-clan-queue-refill-eu",
     "landing-random-clan-queue-refill-asia",
+    # Daily observation floor (2026-05-02) was promoted to a 6-hourly
+    # rolling floor on 2026-05-09 and renamed to drop the `daily-` prefix.
+    # The 4 daily-* rows must be deleted so beat doesn't keep firing the
+    # old daily schedule alongside the new 6-hourly one.
+    "daily-observation-floor-na",
+    "daily-observation-floor-eu",
+    "daily-observation-floor-asia",
 ]
 
 
@@ -105,17 +154,23 @@ def register_periodic_schedules(sender, **kwargs):
             name="clan-battle-summary-warmer").update(enabled=False)
 
     landing_warm_minutes = int(os.getenv("LANDING_PAGE_WARM_MINUTES", "120"))
-    landing_warm_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=landing_warm_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
-
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, landing_warm_minutes)
+        landing_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"landing-page-warmer-{realm}",
             defaults={
                 "task": "warships.tasks.warm_landing_page_content_task",
-                "interval": landing_warm_schedule,
+                "crontab": landing_warm_schedule,
+                "interval": None,
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"include_recent": True, "realm": realm}),
@@ -130,16 +185,23 @@ def register_periodic_schedules(sender, **kwargs):
     # out-of-band so a rebuild never adds latency to a request.
     recent_players_warm_minutes = int(
         os.getenv("LANDING_RECENT_PLAYERS_WARM_MINUTES", "180"))
-    recent_players_warm_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=recent_players_warm_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, recent_players_warm_minutes)
+        recent_players_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"recent-players-warmer-{realm}",
             defaults={
                 "task": "warships.tasks.warm_landing_recent_players_task",
-                "interval": recent_players_warm_schedule,
+                "crontab": recent_players_warm_schedule,
+                "interval": None,
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -174,17 +236,23 @@ def register_periodic_schedules(sender, **kwargs):
 
     # -- Player Distribution Warmer (split from landing warmer) --
     dist_warm_minutes = int(os.getenv("DISTRIBUTION_WARM_MINUTES", "360"))
-    dist_warm_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=dist_warm_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
-
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, dist_warm_minutes)
+        dist_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"player-distribution-warmer-{realm}",
             defaults={
                 "task": "warships.tasks.warm_player_distributions_task",
-                "interval": dist_warm_schedule,
+                "crontab": dist_warm_schedule,
+                "interval": None,
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -194,17 +262,23 @@ def register_periodic_schedules(sender, **kwargs):
 
     # -- Player Correlation Warmer (split from landing warmer) --
     corr_warm_minutes = int(os.getenv("CORRELATION_WARM_MINUTES", "360"))
-    corr_warm_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=corr_warm_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
-
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, corr_warm_minutes)
+        corr_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"player-correlation-warmer-{realm}",
             defaults={
                 "task": "warships.tasks.warm_player_correlations_task",
-                "interval": corr_warm_schedule,
+                "crontab": corr_warm_schedule,
+                "interval": None,
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -214,17 +288,23 @@ def register_periodic_schedules(sender, **kwargs):
 
     hot_entity_warm_minutes = int(
         os.getenv("HOT_ENTITY_CACHE_WARM_MINUTES", "30"))
-    hot_entity_warm_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=hot_entity_warm_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
-
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, hot_entity_warm_minutes)
+        hot_entity_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"hot-entity-cache-warmer-{realm}",
             defaults={
                 "task": "warships.tasks.warm_hot_entity_caches_task",
-                "interval": hot_entity_warm_schedule,
+                "crontab": hot_entity_warm_schedule,
+                "interval": None,
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -257,17 +337,23 @@ def register_periodic_schedules(sender, **kwargs):
 
     recently_viewed_warm_minutes = int(
         os.getenv("RECENTLY_VIEWED_WARM_MINUTES", "10"))
-    recently_viewed_warm_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=recently_viewed_warm_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
-
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, recently_viewed_warm_minutes)
+        recently_viewed_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"recently-viewed-player-warmer-{realm}",
             defaults={
                 "task": "warships.tasks.warm_recently_viewed_players_task",
-                "interval": recently_viewed_warm_schedule,
+                "crontab": recently_viewed_warm_schedule,
+                "interval": None,
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -355,21 +441,30 @@ def register_periodic_schedules(sender, **kwargs):
         )
 
     # -- Incremental Player Refresh (per realm) --
-    # Default 180 min: each cycle walks ~1200 players × 6 WG API calls + DB
-    # writes and takes 35-78 min/realm. With -c 2 worker slots the safe minimum
-    # interval is cycle_time × num_realms / num_slots ≈ 117 min.
+    # Default 180 min cycle, striped per realm via REALM_INTERVAL_OFFSETS so
+    # NA fires at minute 0 of hours 0,3,6,…, EU at hours 1,4,7,…, ASIA at
+    # hours 2,5,8,…. Each cycle walks ~1200 players × 6 WG API calls + DB
+    # writes and takes 35-78 min/realm. Striping keeps at most one realm
+    # mid-cycle so the background worker stays utilised but not stacked.
     player_refresh_minutes = int(
         os.getenv("PLAYER_REFRESH_INTERVAL_MINUTES", "180"))
-    player_refresh_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=player_refresh_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, player_refresh_minutes)
+        player_refresh_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"incremental-player-refresh-{realm}",
             defaults={
                 "task": "warships.tasks.incremental_player_refresh_task",
-                "interval": player_refresh_schedule,
+                "crontab": player_refresh_schedule,
+                "interval": None,
                 "enabled": crawler_schedules_enabled,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -378,18 +473,28 @@ def register_periodic_schedules(sender, **kwargs):
         )
 
     # -- Incremental Ranked Refresh (per realm) --
+    # Default 120 min cycle, striped per realm. With 3 realms the stride is
+    # 40 min: NA at minute 0 of even hours, EU at minute 40 of even hours,
+    # ASIA at minute 20 of odd hours.
     ranked_refresh_minutes = int(
         os.getenv("RANKED_REFRESH_INTERVAL_MINUTES", "120"))
-    ranked_refresh_schedule, _ = IntervalSchedule.objects.get_or_create(
-        every=ranked_refresh_minutes,
-        period=IntervalSchedule.MINUTES,
-    )
     for realm in sorted(VALID_REALMS):
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, ranked_refresh_minutes)
+        ranked_refresh_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute_str,
+            hour=hour_str,
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
         PeriodicTask.objects.update_or_create(
             name=f"incremental-ranked-refresh-{realm}",
             defaults={
                 "task": "warships.tasks.incremental_ranked_data_task",
-                "interval": ranked_refresh_schedule,
+                "crontab": ranked_refresh_schedule,
+                "interval": None,
                 "enabled": crawler_schedules_enabled,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
@@ -397,37 +502,47 @@ def register_periodic_schedules(sender, **kwargs):
             },
         )
 
-    # -- Daily BattleObservation Floor (per realm) --
-    # Sits alongside the tiered incremental crawler as a guaranteed
-    # daily floor — fills any active-7d player whose latest
-    # BattleObservation is older than ~22h. Prevents the diff lane from
-    # collapsing multi-day activity into a single huge event.
+    # -- Rolling BattleObservation Floor (per realm, every 6h) --
+    # Promoted from a daily cron to a 6-hourly cron on 2026-05-09 to tighten
+    # battle pickup. Each realm fires 4× per day, striped via
+    # REALM_INTERVAL_OFFSETS (2h stride within the 6h cycle) so NA, EU,
+    # and ASIA never run concurrently. The floor walks active-7d players
+    # whose latest BattleObservation is older than
+    # BATTLE_OBSERVATION_FLOOR_HOURS (default tightened to 8h alongside the
+    # cadence change). Most cycles return <100 candidates because the
+    # tiered crawler covers hot players within 12h.
     # Runbook: agents/runbooks/runbook-battle-observation-floor-2026-05-02.md
-    obs_floor_hour = int(os.getenv("BATTLE_OBSERVATION_FLOOR_HOUR", "1"))
+    obs_floor_minute_str = os.getenv("BATTLE_OBSERVATION_FLOOR_MINUTE", "15")
+    obs_floor_base_hour = int(os.getenv("BATTLE_OBSERVATION_FLOOR_HOUR", "1"))
+    obs_floor_base_minute = (
+        obs_floor_base_hour * 60 + int(obs_floor_minute_str))
     for realm in sorted(VALID_REALMS):
-        realm_hour = (obs_floor_hour
-                      + REALM_CRAWL_CRON_HOURS.get(realm, 0)) % 24
+        # 6h cycle = 360 minutes. Striped offsets: NA at base, EU at
+        # base+2h, ASIA at base+4h.
+        minute_str, hour_str = _realm_crontab_for_cycle(
+            realm, 360, base_minute=obs_floor_base_minute)
         obs_floor_schedule, _ = CrontabSchedule.objects.get_or_create(
-            minute="15",
-            hour=str(realm_hour),
+            minute=minute_str,
+            hour=hour_str,
             day_of_week="*",
             day_of_month="*",
             month_of_year="*",
             timezone="UTC",
         )
         PeriodicTask.objects.update_or_create(
-            name=f"daily-observation-floor-{realm}",
+            name=f"observation-floor-{realm}",
             defaults={
                 "task": "warships.tasks.ensure_daily_battle_observations_task",
                 "crontab": obs_floor_schedule,
+                "interval": None,
                 "enabled": crawler_schedules_enabled,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
                 "description": (
-                    f"Daily floor for BattleObservation coverage "
+                    f"Rolling 6-hourly floor for BattleObservation coverage "
                     f"({realm.upper()}). Walks active-7d players whose "
-                    f"latest observation is >22h old. Defers while a "
-                    f"clan crawl holds its realm lock."
+                    f"latest observation exceeds BATTLE_OBSERVATION_FLOOR_HOURS. "
+                    f"Defers while a clan crawl holds its realm lock."
                 ),
             },
         )

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -1268,10 +1268,10 @@ def ensure_daily_battle_observations_task(self, realm=DEFAULT_REALM):
     Walks `Player.objects.filter(realm=..., is_hidden=False,
     last_battle_date >= today - DAYS)` and dispatches a fresh observation
     for any whose latest BattleObservation is older than
-    `BATTLE_OBSERVATION_FLOOR_HOURS` (default 22h). The intent is to
-    guarantee at-most-24h spacing between observations for the active
-    population — sitting alongside the tiered incremental crawler which
-    is best-effort.
+    `BATTLE_OBSERVATION_FLOOR_HOURS` (default 8h, tightened from 22h on
+    2026-05-09 alongside the promotion to a rolling 6-hourly Beat
+    schedule). Sits alongside the tiered incremental crawler which is
+    best-effort.
 
     Issues 2 WG calls/player when ranked capture is off for the realm,
     3 calls when it's on (random + ranked baseline rolled into the same
@@ -1302,7 +1302,7 @@ def ensure_daily_battle_observations_task(self, realm=DEFAULT_REALM):
             "ensure_daily_battle_observations",
             realm=realm,
             days=int(os.getenv("BATTLE_OBSERVATION_FLOOR_DAYS", "7")),
-            stale_hours=int(os.getenv("BATTLE_OBSERVATION_FLOOR_HOURS", "22")),
+            stale_hours=int(os.getenv("BATTLE_OBSERVATION_FLOOR_HOURS", "8")),
             limit=int(os.getenv("BATTLE_OBSERVATION_FLOOR_LIMIT", "3000")),
             delay=float(os.getenv("BATTLE_OBSERVATION_FLOOR_DELAY", "0.3")),
         )

--- a/server/warships/tests/test_periodic_schedule_topology.py
+++ b/server/warships/tests/test_periodic_schedule_topology.py
@@ -1,0 +1,217 @@
+"""Periodic schedule topology tests.
+
+Pins the contract for `register_periodic_schedules` in `signals.py`:
+
+1. All expected schedule names exist after post_migrate.
+2. Per-realm interval-style families are crontab schedules, not
+   IntervalSchedules — they're striped per realm via
+   `REALM_INTERVAL_OFFSETS` so at most one realm fires at a time.
+3. Realm offsets are pairwise distinct.
+4. Rolling observation floor fires 4× per day per realm.
+5. Retired schedule names get deleted on each registration.
+
+This file addresses the open follow-up from
+`agents/runbooks/runbook-periodic-task-topology-2026-04-11.md` (#3) and
+catches the most common regressions: forgetting to clear `interval`
+when transitioning a row from interval → crontab, and forgetting to
+add an old name to `_RETIRED_SCHEDULE_NAMES` after a rename.
+"""
+from __future__ import annotations
+
+from django.apps import apps
+from django.test import TestCase
+from django_celery_beat.models import PeriodicTask
+
+from warships.models import VALID_REALMS
+from warships.signals import (
+    REALM_INTERVAL_OFFSETS,
+    _realm_crontab_for_cycle,
+    register_periodic_schedules,
+)
+
+
+# Schedule families that get a per-realm row with a striped crontab.
+# Tuples are (name_prefix, cycle_env_default_minutes).
+STRIPED_PER_REALM_FAMILIES = [
+    ("landing-page-warmer", 120),
+    ("recent-players-warmer", 180),
+    ("player-distribution-warmer", 360),
+    ("player-correlation-warmer", 360),
+    ("hot-entity-cache-warmer", 30),
+    ("recently-viewed-player-warmer", 10),
+    ("incremental-player-refresh", 180),
+    ("incremental-ranked-refresh", 120),
+]
+
+
+class ExpectedScheduleNamesTests(TestCase):
+    """Test 1: full expected schedule set exists after post_migrate."""
+
+    def test_all_per_realm_schedules_registered(self):
+        # post_migrate runs during the per-test DB build, so the rows
+        # exist at the start of the test. We just need to verify they
+        # all show up.
+        for prefix, _cycle in STRIPED_PER_REALM_FAMILIES:
+            for realm in VALID_REALMS:
+                name = f"{prefix}-{realm}"
+                self.assertTrue(
+                    PeriodicTask.objects.filter(name=name).exists(),
+                    f"Missing PeriodicTask row: {name}",
+                )
+
+    def test_observation_floor_per_realm(self):
+        for realm in VALID_REALMS:
+            self.assertTrue(
+                PeriodicTask.objects.filter(
+                    name=f"observation-floor-{realm}").exists(),
+                f"Missing observation-floor-{realm}",
+            )
+
+    def test_singleton_schedules_present(self):
+        for name in (
+            "player-enrichment-kickstart",
+            "battle-history-daily-rollup",
+            "poll-tracked-player-battles",
+        ):
+            self.assertTrue(
+                PeriodicTask.objects.filter(name=name).exists(),
+                f"Missing singleton PeriodicTask row: {name}",
+            )
+
+
+class StripedSchedulesAreCrontabTests(TestCase):
+    """Test 2: striped families use crontab, not interval."""
+
+    def test_striped_families_use_crontab(self):
+        for prefix, _cycle in STRIPED_PER_REALM_FAMILIES:
+            for realm in VALID_REALMS:
+                name = f"{prefix}-{realm}"
+                row = PeriodicTask.objects.get(name=name)
+                self.assertIsNotNone(
+                    row.crontab,
+                    f"{name} should be on a CrontabSchedule",
+                )
+                self.assertIsNone(
+                    row.interval,
+                    f"{name} should not also have an IntervalSchedule attached",
+                )
+
+
+class RealmOffsetsDistinctTests(TestCase):
+    """Test 3: per-realm crontab offsets are pairwise distinct."""
+
+    def _crontab_signature(self, name):
+        row = PeriodicTask.objects.get(name=name)
+        return (row.crontab.minute, row.crontab.hour)
+
+    def test_player_refresh_offsets_distinct(self):
+        sigs = {
+            realm: self._crontab_signature(f"incremental-player-refresh-{realm}")
+            for realm in VALID_REALMS
+        }
+        self.assertEqual(
+            len(set(sigs.values())), len(VALID_REALMS),
+            f"Player refresh schedules collide: {sigs}",
+        )
+
+    def test_observation_floor_offsets_distinct(self):
+        sigs = {
+            realm: self._crontab_signature(f"observation-floor-{realm}")
+            for realm in VALID_REALMS
+        }
+        self.assertEqual(
+            len(set(sigs.values())), len(VALID_REALMS),
+            f"Observation floor schedules collide: {sigs}",
+        )
+
+
+class ObservationFloorRunsFourTimesADayTests(TestCase):
+    """Test 4: rolling 6-hourly floor fires 4× per day per realm."""
+
+    def test_observation_floor_fires_four_times_per_day(self):
+        for realm in VALID_REALMS:
+            row = PeriodicTask.objects.get(name=f"observation-floor-{realm}")
+            hour_segments = row.crontab.hour.split(",")
+            self.assertEqual(
+                len(hour_segments), 4,
+                f"observation-floor-{realm} should fire 4×/day, "
+                f"got hour='{row.crontab.hour}'",
+            )
+
+
+class RetirementListPrunesOldRowsTests(TestCase):
+    """Test 5: re-running registration deletes retired names."""
+
+    def test_daily_observation_floor_legacy_name_is_pruned(self):
+        # Pre-create the legacy row that the 2026-05-09 promotion retired.
+        # `register_periodic_schedules` deletes any name in
+        # `_RETIRED_SCHEDULE_NAMES` at the top of its run.
+        from django_celery_beat.models import IntervalSchedule
+        legacy_schedule, _ = IntervalSchedule.objects.get_or_create(
+            every=1440, period=IntervalSchedule.MINUTES,
+        )
+        PeriodicTask.objects.create(
+            name="daily-observation-floor-na",
+            task="warships.tasks.ensure_daily_battle_observations_task",
+            interval=legacy_schedule,
+        )
+        self.assertTrue(
+            PeriodicTask.objects.filter(
+                name="daily-observation-floor-na").exists(),
+        )
+
+        register_periodic_schedules(sender=apps.get_app_config("warships"))
+
+        self.assertFalse(
+            PeriodicTask.objects.filter(
+                name="daily-observation-floor-na").exists(),
+            "Retired name daily-observation-floor-na should have been deleted",
+        )
+
+
+class RealmCrontabHelperTests(TestCase):
+    """Direct unit coverage of the striping helper."""
+
+    def test_180min_cycle_3_realms(self):
+        # NA hour=0,3,6,…; EU hour=1,4,7,…; ASIA hour=2,5,8,…
+        na_min, na_hr = _realm_crontab_for_cycle("na", 180)
+        eu_min, eu_hr = _realm_crontab_for_cycle("eu", 180)
+        as_min, as_hr = _realm_crontab_for_cycle("asia", 180)
+
+        self.assertEqual(na_min, "0")
+        self.assertEqual(na_hr, "0,3,6,9,12,15,18,21")
+        self.assertEqual(eu_min, "0")
+        self.assertEqual(eu_hr, "1,4,7,10,13,16,19,22")
+        self.assertEqual(as_min, "0")
+        self.assertEqual(as_hr, "2,5,8,11,14,17,20,23")
+
+    def test_30min_cycle_uses_minute_list_with_wildcard_hour(self):
+        # NA fires every 30min at :00 :30; EU at :10 :40; ASIA at :20 :50
+        na_min, na_hr = _realm_crontab_for_cycle("na", 30)
+        eu_min, eu_hr = _realm_crontab_for_cycle("eu", 30)
+        as_min, as_hr = _realm_crontab_for_cycle("asia", 30)
+
+        self.assertEqual(na_min, "0,30")
+        self.assertEqual(eu_min, "10,40")
+        self.assertEqual(as_min, "20,50")
+        for hr in (na_hr, eu_hr, as_hr):
+            self.assertEqual(hr, "*")
+
+    def test_120min_cycle_3_realms(self):
+        # stride = 40min: NA min=0 hr even, EU min=40 hr even, ASIA min=20 hr odd
+        na_min, na_hr = _realm_crontab_for_cycle("na", 120)
+        eu_min, eu_hr = _realm_crontab_for_cycle("eu", 120)
+        as_min, as_hr = _realm_crontab_for_cycle("asia", 120)
+
+        self.assertEqual(na_min, "0")
+        self.assertEqual(na_hr, "0,2,4,6,8,10,12,14,16,18,20,22")
+        self.assertEqual(eu_min, "40")
+        self.assertEqual(eu_hr, "0,2,4,6,8,10,12,14,16,18,20,22")
+        self.assertEqual(as_min, "20")
+        self.assertEqual(as_hr, "1,3,5,7,9,11,13,15,17,19,21,23")
+
+    def test_offsets_dictionary_covers_all_realms(self):
+        # Catches forgetting to register a new realm in the offset map.
+        for realm in VALID_REALMS:
+            self.assertIn(realm, REALM_INTERVAL_OFFSETS,
+                          f"REALM_INTERVAL_OFFSETS missing realm {realm}")


### PR DESCRIPTION
## Summary

- Replaces 8 `IntervalSchedule`-based per-realm warmer/refresh families with crontab schedules striped via a new `REALM_INTERVAL_OFFSETS = {'na': 0, 'eu': 1, 'asia': 2}` map. New helper `_realm_crontab_for_cycle(realm, cycle_minutes, base_minute=0)` derives each realm's `(minute, hour)` stripe from the cycle length.
- Promotes the BattleObservation floor from a single daily cron per realm to a rolling 6-hourly cron (4 fires/day per realm, 2h stride between realms). `BATTLE_OBSERVATION_FLOOR_HOURS` default tightens 22h → 8h.
- Adds `test_periodic_schedule_topology.py` (12 tests) covering registration, crontab vs interval, offset distinctness, observation-floor cadence, retirement pruning, and the helper itself. Closes follow-up #3 from the 2026-04-11 topology runbook.
- Reconciles `runbook-periodic-task-topology-2026-04-11.md`, `runbook-battle-observation-floor-2026-05-02.md`, and `CLAUDE.md`.

## Why

The pre-change topology had all 3 realms firing each interval family in lockstep on every tick, queueing up serially behind their `cache.add` realm locks and producing bursty load on the background worker. Striping smooths the load curve. Combined with the new floor cadence, worst-case "battle landed in DB" lag for any active-7d player drops from ~24h to ~8h regardless of whether the tiered crawler reaches them.

## Test plan

- [x] New topology suite green — 12/12
- [x] Curated release gate green — 243/243 (test_views, test_landing, test_realm_isolation, test_data_product_contracts)
- [ ] After merge + deploy: verify `PeriodicTask` table has only the new `observation-floor-{realm}` rows (no leftover `daily-observation-floor-{realm}`)
- [ ] Watch `/var/log/celery-background.log` for ~12h post-deploy: expect at most one realm mid-cycle at any moment for each striped family

🤖 Generated with [Claude Code](https://claude.com/claude-code)