### PR TITLE
perf(landing): cache score_best_clans() ranking to stop DB-CPU stampede

### DIFF
--- a/server/warships/data.py
+++ b/server/warships/data.py
@@ -5372,6 +5372,15 @@ CLAN_BATTLE_ACTIVITY_BADGE_RECENCY_WEIGHTS = (
 )
 BEST_CLAN_SORTS = ('overall', 'wr')
 
+# Read-through cache TTL for the full scored Best-clan ranking (see
+# score_best_clans). The three aggregate queries it runs scan the full
+# player/playerexplorersummary tables (~14-18s each) and dominate DB CPU;
+# caching the ranking lets frequent landing warms reuse it instead of
+# rescanning. Default 3h — the ranking changes slowly, well within tolerance.
+# See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md (CPU axis).
+SCORE_BEST_CLANS_CACHE_TTL = int(
+    os.environ.get('SCORE_BEST_CLANS_CACHE_TTL', 3 * 60 * 60))
+
 
 def _minmax_normalize(values: list[float]) -> list[float]:
     """Min-max normalize a list of floats to [0, 1]. Returns 0.5 for constant lists."""
@@ -5557,6 +5566,22 @@ def score_best_clans(limit: int = BULK_CACHE_CLAN_MEMBER_CLANS, realm: str = DEF
     normalized_sort = (sort or 'overall').strip().lower()
     if normalized_sort not in BEST_CLAN_SORTS:
         raise ValueError(f"sort must be one of: {', '.join(BEST_CLAN_SORTS)}")
+
+    # Read-through cache of the full scored ranking, keyed on (realm, sort)
+    # independent of `limit` (limit only slices the tail below, so all callers
+    # share one computation). TTL-only — intentionally NOT invalidated by the
+    # landing dirty-key path: per-clan-write invalidation forcing a recompute
+    # on every warm was the DB-CPU saturation root cause. The ranking changes
+    # slowly; SCORE_BEST_CLANS_CACHE_TTL bounds staleness.
+    # See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+    # Bump the `v1` key version if the scoring formula/weights change, so a
+    # deploy serves freshly-scored rankings instead of up to TTL of old ones.
+    cache_key = realm_cache_key(
+        realm, f'best-clans:scored:v1:{normalized_sort}')
+    cached = cache.get(cache_key)
+    if cached is not None:
+        cached_ids, cached_metrics = cached
+        return list(cached_ids[:limit]), cached_metrics
 
     now = django_timezone.now()
 
@@ -5774,15 +5799,20 @@ def score_best_clans(limit: int = BULK_CACHE_CLAN_MEMBER_CLANS, realm: str = DEF
     else:
         raise ValueError(f"sort must be one of: {', '.join(BEST_CLAN_SORTS)}")
 
-    top = ranked_rows[:limit]
+    all_clan_ids = [int(row['clan_id']) for row in ranked_rows]
 
-    if top:
+    # Cache the full ranking (all candidates, sorted) so every caller — across
+    # limits — reuses this computation until the TTL lapses.
+    cache.set(cache_key, (all_clan_ids, cb_metrics_by_clan),
+              SCORE_BEST_CLANS_CACHE_TTL)
+
+    if all_clan_ids:
         logging.info(
             "score_best_clans: top %d clans for sort=%s from %d candidates",
-            len(top), normalized_sort, len(candidates),
+            min(limit, len(all_clan_ids)), normalized_sort, len(candidates),
         )
 
-    return [int(row['clan_id']) for row in top], cb_metrics_by_clan
+    return all_clan_ids[:limit], cb_metrics_by_clan
 
 
 def bulk_load_player_cache(

--- a/server/warships/tests/test_landing.py
+++ b/server/warships/tests/test_landing.py
@@ -10,6 +10,18 @@ from warships.landing import LANDING_CACHE_TTL, LANDING_CLAN_CACHE_TTL, LANDING_
 from warships.models import Clan, LandingPlayerBestSnapshot, LandingRecentPlayersSnapshot, Player, PlayerExplorerSummary, realm_cache_key
 
 
+def _clear_landing_snapshots():
+    # warm_landing_page_content materializes the Landing*Snapshot rows via a
+    # ThreadPoolExecutor; those threads commit on separate DB connections
+    # OUTSIDE the test transaction, so the rows survive a TestCase rollback
+    # and leak across tests. The recent-players surface then serves the stale
+    # Tier-2 snapshot instead of rebuilding inline, breaking tests that expect
+    # a fresh build (only under the full suite; passes in isolation). Delete
+    # the leaked rows at the start of each test that reads the surface.
+    LandingRecentPlayersSnapshot.objects.all().delete()
+    LandingPlayerBestSnapshot.objects.all().delete()
+
+
 class LandingHelperTests(TestCase):
     def setUp(self):
         cache.clear()
@@ -1093,6 +1105,11 @@ class LandingHelperTests(TestCase):
     def test_get_landing_recent_players_payload_cold_cache_builds_inline(self):
         # First-ever read after a Redis flush: no cache, no warmer tick yet.
         # Build inline so the surface isn't empty until the next 3h tick.
+        # Clear any snapshot leaked by an earlier threaded warm test (committed
+        # outside the test transaction) so the Tier-2 fallback doesn't
+        # short-circuit the inline build. Safe here — this test spawns no
+        # threads, so the delete can't deadlock a concurrent threaded warm.
+        _clear_landing_snapshots()
         with patch('warships.landing._build_recent_players', return_value=[{'name': 'cold-player'}]) as mock_build:
             from warships.landing import get_landing_recent_players_payload
             payload = get_landing_recent_players_payload()
@@ -1557,6 +1574,7 @@ class LandingRecentPlayersSnapshotTests(TestCase):
 
     def setUp(self):
         cache.clear()
+        _clear_landing_snapshots()
 
     def test_redis_hit_does_not_query_db_or_rebuild(self):
         # Pre-populate Redis. The DB snapshot does NOT exist. A read should

--- a/server/warships/tests/test_landing.py
+++ b/server/warships/tests/test_landing.py
@@ -540,6 +540,47 @@ class LandingHelperTests(TestCase):
         self.assertEqual(wr_payload[0]['name'], 'WRLeader')
         self.assertIn('avg_cb_battles', wr_payload[0])
 
+    def test_score_best_clans_caches_full_ranking_until_ttl(self):
+        # Regression guard for the DB-CPU fix: score_best_clans() must serve a
+        # cached ranking on repeat calls instead of rescanning the player /
+        # playerexplorersummary tables on every landing warm.
+        # See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+        now = timezone.now()
+        clan = Clan.objects.create(
+            clan_id=8201, name='CacheClan', tag='CC', members_count=12,
+            cached_clan_wr=58.0, cached_total_battles=300000,
+            cached_active_member_count=10,
+        )
+        for index in range(5):
+            player = Player.objects.create(
+                name=f'CacheClanP{index}', player_id=820100 + index, clan=clan,
+                pvp_battles=5000, pvp_wins=2700, days_since_last_battle=3,
+            )
+            PlayerExplorerSummary.objects.create(
+                player=player, player_score=8.0,
+                clan_battle_total_battles=15, clan_battle_overall_win_rate=55.0,
+                clan_battle_summary_updated_at=now - timedelta(days=30),
+            )
+
+        first_ids, _ = score_best_clans(sort='overall')
+        self.assertIn(8201, first_ids)
+
+        # A smaller limit reuses the same cached computation (sliced).
+        one_id, _ = score_best_clans(sort='overall', limit=1)
+        self.assertEqual(one_id, first_ids[:1])
+
+        # Disqualify the clan; within the TTL the cache still returns it,
+        # proving the second call did not recompute.
+        clan.cached_total_battles = 1
+        clan.save(update_fields=['cached_total_battles'])
+        cached_ids, _ = score_best_clans(sort='overall')
+        self.assertEqual(cached_ids, first_ids)
+
+        # Clearing the cache forces a fresh compute that reflects the change.
+        cache.clear()
+        fresh_ids, _ = score_best_clans(sort='overall')
+        self.assertNotIn(8201, fresh_ids)
+
     def test_best_clan_wr_sort_ignores_tiny_cb_samples(self):
         now = timezone.now()
 

--- a/server/warships/tests/test_views.py
+++ b/server/warships/tests/test_views.py
@@ -8,7 +8,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from warships.landing import LANDING_CLANS_BEST_CACHE_KEY, LANDING_CLANS_BEST_PUBLISHED_CACHE_KEY, LANDING_CLANS_CACHE_KEY, LANDING_CLANS_PUBLISHED_CACHE_KEY, LANDING_PLAYER_LIMIT, LANDING_RECENT_CLANS_CACHE_KEY, LANDING_RECENT_PLAYERS_CACHE_KEY, landing_best_clan_cache_key, landing_best_clan_published_cache_key, landing_player_cache_key, landing_player_published_cache_key, warm_landing_page_content
-from warships.models import Player, Clan, PlayerDailyShipStats, PlayerExplorerSummary, realm_cache_key
+from warships.models import Player, Clan, PlayerDailyShipStats, PlayerExplorerSummary, realm_cache_key, LandingRecentPlayersSnapshot, LandingPlayerBestSnapshot
 from warships.views import PUBLIC_API_THROTTLES, landing_players, _missing_player_lookup_cache_key
 
 
@@ -4587,6 +4587,20 @@ class ApiContractTests(TestCase):
 
 
 class ApiThrottleTests(TestCase):
+    def setUp(self):
+        # Cross-test leakage cleanup. Two stores survive a TestCase rollback:
+        #   1. Redis (the CI cache) is not transactional — clear it.
+        #   2. Landing snapshot rows: warm_landing_page_content uses a
+        #      ThreadPoolExecutor, and those threads write the durable
+        #      Landing*Snapshot rows on separate DB connections that COMMIT
+        #      outside this test's transaction. An earlier warm test thus
+        #      leaves an empty recent-players snapshot that the endpoint serves
+        #      as the Tier-2 fallback here — making the surface return 0 rows
+        #      (only under the full suite; passes in isolation). Delete them.
+        cache.clear()
+        LandingRecentPlayersSnapshot.objects.all().delete()
+        LandingPlayerBestSnapshot.objects.all().delete()
+
     def test_landing_players_endpoint_declares_public_api_throttles(self):
         self.assertEqual(landing_players.cls.throttle_classes,
                          PUBLIC_API_THROTTLES)


### PR DESCRIPTION
## Problem

The managed Postgres cluster has been firing continuous CPU-high alerts since 2026-05-01 (209 episodes in 24 days, repeatedly pegging 100%). `pg_stat_statements` traced the load to `score_best_clans()`: its three aggregate queries scan the 11 GB `warships_player` / `warships_playerexplorersummary` tables (~14–18s each) and were being recomputed **~2,180×/day** — the dominant DB-CPU consumer.

## Root cause

`score_best_clans()` was recomputed from scratch on every landing **Best-mode** cache miss / warm. Each clan write (`update_clan_data` / `refresh_clan_cached_aggregates` → `invalidate_landing_clan_caches`) sets a **no-expiry** dirty key and queues a landing republish warm. With the clan crawl + per-clan refreshes keeping the cache perpetually dirty, warms fired ~8/hr, ran concurrently (dedup lock not throttling), and took 346–423s each under contention — a self-reinforcing feedback loop. `EXPLAIN` confirms the queries are already index-driven, so the fix is **frequency reduction, not an index**.

Full diagnosis: `agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md` (CPU axis).

## Change

Add a read-through cache of the full scored ranking, keyed on `(realm, sort)` — independent of `limit` (which only slices the tail, so all callers share one computation). TTL via `SCORE_BEST_CLANS_CACHE_TTL` (default 3h). **Intentionally not wired to the landing dirty-key invalidation** — that per-write recompute was the root cause; the ranking changes slowly and the TTL bounds staleness.

## Testing

- New: `test_score_best_clans_caches_full_ranking_until_ttl` (serves cached ranking within TTL, recomputes after clear, shares across limits).
- Full 244-test backend release gate passes.

## Prod verification (already deployed — release `20260524180220`)

Invoking `score_best_clans(realm='na', sort='overall')` twice on live prod: **31.03s cold → 0.002s cached**, identical results. Healthcheck green.

## Follow-ups (not in this PR)

- Optional slice 2/3: debounce per-clan-write `invalidate_landing_clan_caches()`; fix the landing-warm dedup lock.
- Watch ~24h: DO CPU alert volume, `warm_landing_page_content_task` durations, `pg_stat_statements` `calls` plateau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)