### PR TITLE
fix: stop background-queue flood (no-op poll dispatcher + republish debounce)

### DIFF
--- a/server/warships/landing.py
+++ b/server/warships/landing.py
@@ -1,6 +1,7 @@
 import gc
 import json
 import logging
+import os
 import random
 import time
 from datetime import timedelta
@@ -129,6 +130,18 @@ LANDING_PLAYERS_CACHE_NAMESPACE_KEY = 'landing:players:v13:namespace'
 LANDING_CLANS_DIRTY_KEY = 'landing:clans:dirty:v1'
 LANDING_PLAYERS_DIRTY_KEY = 'landing:players:dirty:v1'
 LANDING_RECENT_CLANS_DIRTY_KEY = 'landing:recent_clans:dirty:v1'
+
+# Debounce window for invalidation-driven landing republishes. Every clan/
+# player write calls _queue_landing_republish, as does the published-fallback
+# path on every request while the cache is dirty — so under the clan crawl +
+# landing traffic, a warm was enqueued on essentially every event, flooding
+# the background queue. This coalesces those triggers into at most one warm
+# per window per realm. The scheduled beat warmer (LANDING_PAGE_WARM_MINUTES)
+# is unaffected — it dispatches the task directly, not via this path.
+# See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+LANDING_REPUBLISH_COOLDOWN_SECONDS = int(
+    os.environ.get('LANDING_REPUBLISH_COOLDOWN_SECONDS', '120'))
+LANDING_REPUBLISH_COOLDOWN_KEY = 'landing:republish:cooldown:v1'
 LANDING_CLAN_FEATURED_COUNT = 30
 LANDING_CLAN_MIN_TOTAL_BATTLES = 100000
 LANDING_CLAN_MODES = ('best',)
@@ -580,6 +593,18 @@ def _clear_cache_family_dirty(*dirty_keys: str) -> None:
 
 def _queue_landing_republish(realm: str = DEFAULT_REALM) -> None:
     from warships.tasks import queue_landing_page_warm
+
+    # Debounce: coalesce bursts of invalidations into at most one warm per
+    # LANDING_REPUBLISH_COOLDOWN_SECONDS per realm. cache.add only succeeds
+    # when no cooldown key exists; the key expires on its own and is NOT
+    # cleared by the warm task (unlike queue_landing_page_warm's dispatch
+    # key, which the task deletes on completion — that let republishes
+    # re-fire immediately after every warm). See
+    # agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+    if LANDING_REPUBLISH_COOLDOWN_SECONDS > 0:
+        cooldown_key = realm_cache_key(realm, LANDING_REPUBLISH_COOLDOWN_KEY)
+        if not cache.add(cooldown_key, '1', LANDING_REPUBLISH_COOLDOWN_SECONDS):
+            return
 
     queue_landing_page_warm(realm=realm)
 

--- a/server/warships/signals.py
+++ b/server/warships/signals.py
@@ -615,7 +615,13 @@ def register_periodic_schedules(sender, **kwargs):
     # -- Incremental Battle Capture PoC dispatcher --
     # Runbook: agents/runbooks/runbook-incremental-battle-poc-2026-04-27.md
     # The dispatcher reads BATTLE_TRACKING_PLAYER_NAMES at runtime; if unset it
-    # short-circuits with no work. Production droplet leaves it unset.
+    # short-circuits with no work. Production leaves it unset — so only enable
+    # the every-60s beat entry when names are configured. Otherwise the no-op
+    # task was being dispatched 1440x/day and, while the worker was saturated,
+    # piled up in the background queue (it was ~48% of a 1.6K-message backlog
+    # on 2026-05-24). See runbook-db-cpu-saturation-2026-05-24.md.
+    poll_tracking_enabled = bool(
+        os.getenv("BATTLE_TRACKING_PLAYER_NAMES", "").strip())
     poll_interval_seconds = int(
         os.getenv("BATTLE_TRACKING_POLL_SECONDS", "60"))
     poll_schedule, _ = IntervalSchedule.objects.get_or_create(
@@ -627,10 +633,10 @@ def register_periodic_schedules(sender, **kwargs):
         defaults={
             "task": "warships.tasks.dispatch_tracked_player_polls_task",
             "interval": poll_schedule,
-            "enabled": True,
+            "enabled": poll_tracking_enabled,
             "args": json.dumps([]),
             "kwargs": json.dumps({}),
-            "description": "Incremental battle capture PoC dispatcher. No-op unless BATTLE_TRACKING_PLAYER_NAMES is set.",
+            "description": "Incremental battle capture PoC dispatcher. No-op unless BATTLE_TRACKING_PLAYER_NAMES is set; beat entry disabled when unset.",
         },
     )
 

--- a/server/warships/tests/test_landing.py
+++ b/server/warships/tests/test_landing.py
@@ -593,6 +593,20 @@ class LandingHelperTests(TestCase):
         fresh_ids, _ = score_best_clans(sort='overall')
         self.assertNotIn(8201, fresh_ids)
 
+    def test_queue_landing_republish_debounces_within_cooldown(self):
+        # Regression guard for the background-queue flood: bursts of clan/player
+        # invalidations must coalesce into at most one warm per realm within the
+        # cooldown window. See runbook-db-cpu-saturation-2026-05-24.md.
+        from warships import landing as landing_mod
+        with patch('warships.tasks.queue_landing_page_warm') as mock_warm:
+            landing_mod._queue_landing_republish(realm='na')
+            landing_mod._queue_landing_republish(realm='na')  # within cooldown
+            landing_mod._queue_landing_republish(realm='na')  # within cooldown
+            self.assertEqual(mock_warm.call_count, 1)
+            # A different realm is gated independently.
+            landing_mod._queue_landing_republish(realm='eu')
+            self.assertEqual(mock_warm.call_count, 2)
+
     def test_best_clan_wr_sort_ignores_tiny_cb_samples(self):
         now = timezone.now()
 

--- a/server/warships/tests/test_periodic_schedule_topology.py
+++ b/server/warships/tests/test_periodic_schedule_topology.py
@@ -18,6 +18,9 @@ add an old name to `_RETIRED_SCHEDULE_NAMES` after a rename.
 """
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 from django.apps import apps
 from django.test import TestCase
 from django_celery_beat.models import PeriodicTask
@@ -215,3 +218,23 @@ class RealmCrontabHelperTests(TestCase):
         for realm in VALID_REALMS:
             self.assertIn(realm, REALM_INTERVAL_OFFSETS,
                           f"REALM_INTERVAL_OFFSETS missing realm {realm}")
+
+
+class TrackedPlayerPollGateTests(TestCase):
+    """The every-60s PoC poll dispatcher must only be ENABLED when
+    BATTLE_TRACKING_PLAYER_NAMES is set. On prod (unset) it is a no-op that
+    was being dispatched 1440x/day and piling up in the background queue.
+    See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+    """
+
+    def _registered_poll_task(self):
+        register_periodic_schedules(sender=apps.get_app_config("warships"))
+        return PeriodicTask.objects.get(name="poll-tracked-player-battles")
+
+    def test_poll_dispatcher_disabled_when_no_tracked_players(self):
+        with mock.patch.dict(os.environ, {"BATTLE_TRACKING_PLAYER_NAMES": ""}, clear=False):
+            self.assertFalse(self._registered_poll_task().enabled)
+
+    def test_poll_dispatcher_enabled_when_tracking_configured(self):
+        with mock.patch.dict(os.environ, {"BATTLE_TRACKING_PLAYER_NAMES": "lil_boots"}, clear=False):
+            self.assertTrue(self._registered_poll_task().enabled)


### PR DESCRIPTION
Stacked on #8 (base = `perf/best-clans-scoring-cache-2026-05-24`).

## Problem

The `background` Celery queue had a ~1,650-message backlog (accumulated while the worker was pegged on 346–423s landing warms pre-#8). Sampling the queue: ~48% `dispatch_tracked_player_polls_task`, ~29% `warm_landing_page_content_task`, rest periodic. Both dominant sources are flood bugs.

## Changes

**1. `fix(beat)`: disable the no-op tracked-player poll dispatcher when unconfigured.** `dispatch_tracked_player_polls_task` is a battle-tracking PoC, a pure no-op on prod (`BATTLE_TRACKING_PLAYER_NAMES` unset) yet beat dispatched it every 60s (1,440×/day). Gate the beat entry's `enabled` on the env var being set.

**2. `perf(landing)`: debounce invalidation-driven republish warms.** Every clan/player write (and the published-fallback path on every request while dirty) called `_queue_landing_republish` → `queue_landing_page_warm`. The warm task deletes its own dispatch-dedup key on completion, so a warm re-fired on essentially every event. Coalesce into at most one warm per realm per `LANDING_REPUBLISH_COOLDOWN_SECONDS` (default 120s) via a cooldown key the warm doesn't clear. Scheduled beat warmer unaffected (dispatches the task directly); published fallback covers freshness within the window.

## Testing

- `test_poll_dispatcher_disabled_when_no_tracked_players` / `_enabled_when_tracking_configured`
- `test_queue_landing_republish_debounces_within_cooldown`
- Full backend release gate (259 tests) passes.

## Ops (already done on prod, release `20260524202731`)

- Purged the stale 1,650-message `background` backlog (`acks_late` preserved in-flight).
- Verified post-deploy: poll task `enabled=False`; `background` queue at 0 and not re-accumulating; 0 poll dispatches since deploy.

Runbook: `agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)