### PR TITLE
fix(crawl): route crawl watchdog off the camped crawls queue

### DIFF
--- a/server/battlestats/settings.py
+++ b/server/battlestats/settings.py
@@ -292,7 +292,14 @@ CELERY_WORKER_MAX_TASKS_PER_CHILD = int(
 CELERY_TASK_DEFAULT_QUEUE = 'default'
 CELERY_TASK_ROUTES = {
     'warships.tasks.crawl_all_clans_task': {'queue': 'crawls'},
-    'warships.tasks.ensure_crawl_all_clans_running_task': {'queue': 'crawls'},
+    # The crawl watchdog must NOT share the single-slot `crawls` queue with
+    # the days-long crawl_all_clans_task: it would queue up behind the crawl
+    # (a ~269-deep backlog of no-op checks was observed 2026-05-25) and, worse,
+    # could never run to detect a *zombie* crawl that is camping that slot.
+    # Route it to `default` so it runs promptly every 5 min, self-gates when a
+    # crawl is healthy (lock held + fresh heartbeat → no-op), and can still
+    # clear a stale lock + restart. See runbook-clan-crawl-blocker-2026-04-30.md.
+    'warships.tasks.ensure_crawl_all_clans_running_task': {'queue': 'default'},
     'warships.tasks.incremental_player_refresh_task': {'queue': 'background'},
     'warships.tasks.incremental_ranked_data_task': {'queue': 'background'},
     'warships.tasks.refresh_efficiency_rank_snapshot_task': {'queue': 'background'},

--- a/server/warships/tests/test_task_routing.py
+++ b/server/warships/tests/test_task_routing.py
@@ -23,8 +23,6 @@ def test_long_running_maintenance_tasks_route_to_background():
     routes = settings.CELERY_TASK_ROUTES
 
     expected_tasks = {
-        "warships.tasks.crawl_all_clans_task",
-        "warships.tasks.ensure_crawl_all_clans_running_task",
         "warships.tasks.incremental_player_refresh_task",
         "warships.tasks.incremental_ranked_data_task",
         "warships.tasks.warm_all_clan_tier_distributions_task",
@@ -33,6 +31,21 @@ def test_long_running_maintenance_tasks_route_to_background():
 
     for task_name in expected_tasks:
         assert routes[task_name]["queue"] == "background"
+
+
+def test_clan_crawl_routes_to_crawls_but_watchdog_routes_to_default():
+    # The days-long crawl_all_clans_task owns the single-slot `crawls` queue.
+    # Its watchdog must live on a different queue so it isn't camped behind the
+    # crawl (a ~269-deep backlog of no-op checks was observed 2026-05-25) and
+    # can still run to detect a zombie crawl holding that slot.
+    # See runbook-clan-crawl-blocker-2026-04-30.md.
+    routes = settings.CELERY_TASK_ROUTES
+
+    assert routes["warships.tasks.crawl_all_clans_task"]["queue"] == "crawls"
+    assert (
+        routes["warships.tasks.ensure_crawl_all_clans_running_task"]["queue"]
+        == "default"
+    )
 
 
 def test_startup_cache_warm_task_declares_background_queue():


### PR DESCRIPTION
## Problem

`ensure_crawl_all_clans_running_task` (the clan-crawl watchdog) was routed to the single-slot `crawls` queue (`CELERY_TASK_ROUTES`), shared with the days-long `crawl_all_clans_task`. While a crawl runs it camps the `-c1` worker, so the every-5-min watchdog piles up unconsumed — a **~269-deep backlog** of no-op checks observed 2026-05-25. Worse, because it shares the crawl's queue, the watchdog can **never run to detect a zombie crawl** holding that slot — defeating its entire purpose.

## Fix

Route the watchdog to `default` (already consumed by the `-c3` worker). It now:
- runs promptly every 5 min regardless of crawl state → no pile-up,
- self-gates when the crawl is healthy (lock held + fresh heartbeat → `{"skipped":"running"}`),
- can still clear a stale lock + restart a zombie crawl (`tasks.py:1206-1211`).

The crawl itself stays on `crawls`.

## Also

Fixes `test_long_running_maintenance_tasks_route_to_background`, which had silently gone stale — it asserted the crawl tasks route to `background`, but they've routed to `crawls` since the 2026-04-30 carve-out. It isn't in the CI release-gate set, so the drift went unnoticed. Added an explicit `test_clan_crawl_routes_to_crawls_but_watchdog_routes_to_default`.

## Notes

- Settings-only routing change; the `default` worker already consumes that queue, so no worker reconfiguration.
- The pre-existing ~278 stale watchdog messages on `crawls` will self-drain when the current crawl finishes (fast no-ops); new ticks route to `default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)