### PR TITLE
perf(db): DB size optimization + follow-ups (defaultdb 24→16 GB)

### DIFF
--- a/agents/doc_registry.json
+++ b/agents/doc_registry.json
@@ -1833,6 +1833,32 @@
             "archive_on": [
                 "db-size-optimization-executed-and-reclaimed"
             ]
+        },
+        "agents/runbooks/runbook-db-optimization-followups-2026-05-26.md": {
+            "kind": "runbook",
+            "status": "active",
+            "lifecycle": "dated-active",
+            "section": "operations",
+            "owner": "platform",
+            "aliases": [
+                "db optimization followups",
+                "rollup oom fix",
+                "player serializer wire trim",
+                "warships_player vacuum full",
+                "pgstattuple bloat"
+            ],
+            "tags": [
+                "postgres",
+                "performance",
+                "oom",
+                "rollup",
+                "serializer",
+                "vacuum",
+                "followups"
+            ],
+            "archive_on": [
+                "db-optimization-followups-completed"
+            ]
         }
     }
 }

--- a/agents/doc_registry.json
+++ b/agents/doc_registry.json
@@ -1807,6 +1807,32 @@
             "archive_on": [
                 "cpu-saturation-root-caused-and-resolved"
             ]
+        },
+        "agents/runbooks/runbook-db-size-optimization-2026-05-26.md": {
+            "kind": "runbook",
+            "status": "active",
+            "lifecycle": "dated-active",
+            "section": "operations",
+            "owner": "platform",
+            "aliases": [
+                "db size optimization",
+                "postgres disk bloat",
+                "battles_json bloat",
+                "battleobservation toast reclaim",
+                "db storage headroom"
+            ],
+            "tags": [
+                "postgres",
+                "disk",
+                "storage",
+                "toast",
+                "digitalocean",
+                "performance",
+                "bloat"
+            ],
+            "archive_on": [
+                "db-size-optimization-executed-and-reclaimed"
+            ]
         }
     }
 }

--- a/agents/runbooks/runbook-db-optimization-followups-2026-05-26.md
+++ b/agents/runbooks/runbook-db-optimization-followups-2026-05-26.md
@@ -82,6 +82,22 @@ growth capped) but a regular `VACUUM` does not return it to the OS. To reclaim i
 **Verify:** `pg_total_relation_size('warships_player')` drops by ~the freed amount; `defaultdb` shrinks
 accordingly; API healthy after the lock releases.
 
+### FU-4 — Single-flight lock on `score_best_clans()` (added after the post-VACUUM spike)
+
+Running the FU-3 `VACUUM FULL warships_player` evicted the table from the PG buffer cache; the next
+landing-Best cache-miss callers read the cold pages from disk (`wait: DataFileRead`), one taking
+**2m41s** vs the normal 14-18s, and — with no single-flight lock — concurrent callers stampeded the
+same heavy 3-aggregate scan → a ~3-minute CPU/IO spike that self-resolved as the cache re-warmed.
+
+This was the deferred "slice 3" from `runbook-db-cpu-saturation-2026-05-24.md`. Fixed in `data.py`:
+`score_best_clans()` now wraps its cache-miss compute in a Redis single-flight lock
+(`cache.add(lock_key, …, SCORE_BEST_CLANS_LOCK_TIMEOUT=5m)`). The first caller computes + caches +
+releases; concurrent callers wait up to `SCORE_BEST_CLANS_LOCK_WAIT=30s` (covers the warm compute)
+for the cache, and only fall through to compute themselves if the leader is pathologically slow —
+correctness-preserving (never returns degraded), DB load reduced from N→1 in the common case.
+Test: `test_score_best_clans_single_flight_lock` (test_landing.py). The lock auto-expires
+(`LOCK_TIMEOUT`) so a crash can't deadlock; both env knobs are tunable.
+
 ## Execution order & sequencing
 
 1. **FU-1 + FU-2 together** (both code): implement, run the lean release gate, commit, backend-deploy.

--- a/agents/runbooks/runbook-db-optimization-followups-2026-05-26.md
+++ b/agents/runbooks/runbook-db-optimization-followups-2026-05-26.md
@@ -1,0 +1,99 @@
+# Runbook: DB-optimization follow-ups (post size-reclaim)
+
+_Created: 2026-05-26_
+_Context: The DB size-optimization session (`runbook-db-size-optimization-2026-05-26.md`) reclaimed ~5 GB (`defaultdb` 24 → 19 GB) and made keep=1 BattleObservation compaction durable + live. It left three deferred follow-ups and surfaced one pre-existing bug. This runbook captures and executes them._
+_Status: **COMPLETE** (2026-05-26). FU-1 (rollup OOM rewrite) + FU-2 (serializer wire-trim) shipped in release `20260526125032`; release gate 377 passed; FU-1 smoke-tested on the droplet (yearly rebuild 622,942 rows, peak memory flat — no OOM). FU-3 `VACUUM FULL warships_player` run in a confirmed window: pgstattuple showed heap 45.8% free + TOAST 34% free; table **11 GB → 7.4 GB**, **`defaultdb` 19 GB → 16 GB** (~3.6 GB to OS). Net across both DB sessions: `defaultdb` 24 → 16 GB._
+
+## The three follow-ups
+
+### FU-1 — Nightly-rollup OOM (pre-existing bug; highest value)
+
+**Symptom:** `rebuild_period_rollups_for_date()` (`incremental_battles.py`) OOM-killed at **7.2 GB RSS** on
+the 7.8 GB droplet during the 2026-05-26 monthly/yearly rebuild. Root cause: `_aggregate_into_period_table`
+loads the **entire period's** `PlayerDailyShipStats` rows into Python (`for d in daily_qs:` building a
+`rows` dict) — ~1.1 M rows for a month, ~1.2 M for a year. As the daily table grew, the nightly
+`roll_up_player_daily_ship_stats_task` (`tasks.py:1532`) has been **silently failing** on the
+monthly/yearly tiers (this is why the pre-truncate monthly/yearly counts were partial: 123 K/119 K vs the
+true 617 K/620 K rebuilt via server-side SQL).
+
+**Fix:** push the GROUP BY to the database instead of aggregating in Python. Rewrite
+`_aggregate_into_period_table` to use ORM aggregation streamed in batches:
+
+```python
+from django.db.models import Sum, Min, Max
+agg = (PlayerDailyShipStats.objects
+       .filter(date__gte=target_period_start, date__lte=period_end_inclusive,
+               mode=PlayerDailyShipStats.MODE_RANDOM)
+       .values("player_id", "ship_id")
+       .annotate(battles=Sum("battles"), wins=Sum("wins"), losses=Sum("losses"),
+                 frags=Sum("frags"), damage=Sum("damage"), xp=Sum("xp"),
+                 planes_killed=Sum("planes_killed"), survived_battles=Sum("survived_battles"),
+                 first_event_at=Min("first_event_at"), last_event_at=Max("last_event_at"),
+                 ship_name=Max("ship_name"))
+       .order_by())
+# delete-first stays (idempotent); then bulk_create in batches via .iterator(chunk_size=…)
+```
+
+- Peak memory is bounded by the bulk_create batch (e.g. 5 000), not the period size.
+- **DB-portable** (Postgres + the sqlite used in tests) — required because
+  `test_rebuild_period_rollups_writes_weekly_monthly_yearly` (`test_incremental_battles.py:2891`) runs on
+  sqlite. `ship_name=Max(...)` matches "non-empty wins" since `''` sorts first; `updated_at` stays
+  auto-set by `bulk_create` (no raw SQL).
+- `rebuild_daily_ship_stats_for_date` (`incremental_battles.py:986`) uses the same Python-load pattern but
+  only over **one day** of `BattleEvent` rows (~40 K) — far lower risk; leave as-is this round (note only).
+
+**Verify:** `test_incremental_battles.py` green; then a prod rebuild of the current month/year completes
+without OOM (`free -h` stays healthy on the droplet) and row counts match the daily layer.
+
+### FU-2 — Trim unused JSON from the player-detail wire (perf/efficiency; 0 disk)
+
+**Finding:** `PlayerSerializer` (`serializers.py:100`, `fields = '__all__'`) ships **all 8** JSON columns
+in every `/api/players/<name>` payload and into the Redis `get_cached_player_detail` dict, but the
+frontend reads **none** of `battles_json`, `tiers_json`, `type_json`, `activity_json`,
+`achievements_json` (grep of `client/app`: 0 refs each; only `randoms_json`, `ranked_json`,
+`efficiency_json` are consumed). The detail payload is **not** ODCS-contract-governed (the contracts cover
+`PlayerSummarySerializer` / `PlayerExplorerRowSerializer`, not this serializer), so no contract YAML
+change is needed. Server-side reads of `battles_json` (landing `.values()`, `get_kill_ratio`,
+battle-history baseline, randoms fallback) all read the **model attribute**, unaffected by the serialized
+field set.
+
+**Fix:** switch `PlayerSerializer.Meta` from `fields = '__all__'` to
+`exclude = ['battles_json', 'tiers_json', 'type_json', 'activity_json', 'achievements_json']` (surgical;
+declared `SerializerMethodField`s like `kill_ratio` are unaffected). Saves ~24 KB/player-page on the wire
+**and** shrinks the Redis-cached payload (eases the 3 GB `allkeys-lru` cache).
+
+**Verify:** release gate (`test_views.py` + frontend `npm test`) green — update any test that asserts a
+dropped key in a *response* (most references are fixture setup, not assertions); load a player page in the
+app and confirm every chart still renders (they use the dedicated endpoints + `randoms/ranked/efficiency`).
+
+### FU-3 — Return the pruned `battles_json` ~2 GB to the OS (Tier 2; needs a window)
+
+The inactive-`battles_json` prune freed ~2 GB into **reusable** space inside `warships_player` (11 GB,
+growth capped) but a regular `VACUUM` does not return it to the OS. To reclaim it:
+
+1. `CREATE EXTENSION IF NOT EXISTS pgstattuple;` (contrib, DO-supported) and measure true bloat:
+   `SELECT * FROM pgstattuple('warships_player');` — look at `dead_tuple_percent` / `free_percent`.
+2. If reclaimable space is material, run a **windowed** `VACUUM (FULL, ANALYZE) warships_player;` with
+   `lock_timeout='2min'`. **This takes ACCESS EXCLUSIVE on the 11 GB hot table** — player writes
+   (request-driven refreshes, capture) block for the duration (minutes). Schedule a low-traffic window;
+   captures retry via `acks_late`. Otherwise prefer tuning per-table autovacuum scale factors and leave the
+   space reusable (no lock).
+
+**Verify:** `pg_total_relation_size('warships_player')` drops by ~the freed amount; `defaultdb` shrinks
+accordingly; API healthy after the lock releases.
+
+## Execution order & sequencing
+
+1. **FU-1 + FU-2 together** (both code): implement, run the lean release gate, commit, backend-deploy.
+2. **FU-3** standalone: measure with pgstattuple; the `VACUUM FULL` only in a confirmed low-traffic window.
+
+## Critical files
+- `server/warships/incremental_battles.py` — `_aggregate_into_period_table` (~1282), `rebuild_period_rollups_for_date` (~1353), `rebuild_daily_ship_stats_for_date` (986, note-only).
+- `server/warships/serializers.py:100-107` — `PlayerSerializer.Meta`.
+- `server/warships/tests/test_incremental_battles.py:2891` — rollup test (sqlite; portability gate).
+- `server/warships/tests/test_views.py` — player-detail response assertions (update if any reference a dropped key).
+
+## Rollback
+- FU-1/FU-2 are code; revert the commit + redeploy. FU-1 is behaviour-preserving (same rows, lower memory);
+  FU-2 only removes payload fields the frontend ignores.
+- FU-3 `VACUUM FULL` is not reversible but is safe (rewrites the table); the only risk is the lock window.

--- a/agents/runbooks/runbook-db-size-optimization-2026-05-26.md
+++ b/agents/runbooks/runbook-db-size-optimization-2026-05-26.md
@@ -1,0 +1,271 @@
+# Runbook: Database size optimization (managed Postgres `db-postgresql-nyc3-11231`)
+
+_Created: 2026-05-26_
+_Context: The DO managed Postgres backing battlestats went read-only from disk exhaustion on 2026-05-24 (broke a deploy mid-flight). That acute incident was triaged in `runbook-db-cpu-saturation-2026-05-24.md` (BattleObservation compaction shipped + a one-time `VACUUM FULL` reclaimed ~15 GB). This runbook is the durable follow-up: it documents how the DB is actually used today from live measurement, and lays out a tiered, mostly-reversible plan to cap growth and improve query performance. The dataset is genuinely small; the size is JSON/TOAST bloat on two tables._
+_Status: **PLANNED** — analysis complete and measured 2026-05-26; remediation not yet executed. Authored as a plan, not run. Supersedes the disk axis of `runbook-db-cpu-saturation-2026-05-24.md` (CPU axis there is already resolved; that runbook retains the alert log)._
+
+## Goal & scope (confirmed with user, 2026-05-26)
+
+- **Goal = prevent another read-only outage + improve performance.** *Not* a cost downsize. DO
+  managed Postgres scales storage **up only** — it cannot shrink in place, so reclaimed space is OS
+  **headroom**, not a smaller bill or a smaller disk. A real downsize would require a dump→restore
+  migration to a smaller cluster: **explicitly out of scope** (flagged below).
+- **`battles_json` work = safe/reversible only this round.** Stop shipping it on the wire + prune it
+  for inactive players; rely on the existing derived columns. **No structural refactor** of the
+  battle-history lifetime baseline this round.
+
+## Current state (measured live, 2026-05-26)
+
+Cluster databases: `defaultdb` **23 GB** · `umami` 13 MB · `test_defaultdb` 10 MB · `_dodb` 8 MB.
+Nothing else is large — the "~30 GB" seen on the DO dashboard is the disk-usage figure (incl.
+WAL/temp) on the **60 GB** disk. Actual content is **23 GB**, so headroom is currently healthy and
+this work is **preventive, not acute**.
+
+Top tables (`pg_total_relation_size`, `public` schema):
+
+| Table | Total | Heap | Idx | TOAST | Live | Dead |
+|---|---|---|---|---|---|---|
+| `warships_player` | **11 GB** | 2515 MB | 809 MB | **8391 MB** | 1.03M | 163K |
+| `warships_battleobservation` | **8.5 GB** | 204 MB | 86 MB | **8286 MB** | 922K | 0 |
+| `warships_playerachievementstat` | 1.1 GB | 492 MB | **614 MB** | 0 | 3.68M | 151K |
+| `warships_playerdailyshipstats` | 605 MB | 302 MB | 303 MB | 0 | 1.35M | 151K |
+| `warships_battleevent` | 512 MB | 259 MB | 253 MB | 0 | 1.37M | 11 |
+| `warships_playerexplorersummary` | 370 MB | 190 | 180 | 0 | 617K | 6K |
+| `warships_playerweeklyshipstats` | 235 MB | — | — | 0 | 652K | 0 |
+| `warships_playermonthlyshipstats` | **106 MB** | — | 76 MB | 0 | **0** | 0 |
+| `warships_playeryearlyshipstats` | **64 MB** | — | 34 MB | 0 | **0** | 0 |
+
+Two TOAST/JSON tables are ~83% of the DB. **The data is small; the JSON blobs are not.**
+
+Re-run these to reproduce / measure before & after (always with a `statement_timeout`):
+
+```sql
+SET statement_timeout='90s';
+SELECT pg_size_pretty(pg_database_size('defaultdb'));
+SELECT c.relname,
+       pg_size_pretty(pg_total_relation_size(c.oid))               AS total,
+       pg_size_pretty(pg_relation_size(c.oid))                     AS heap,
+       pg_size_pretty(pg_indexes_size(c.oid))                      AS idx,
+       pg_size_pretty(COALESCE(pg_total_relation_size(c.reltoastrelid),0)) AS toast,
+       s.n_live_tup, s.n_dead_tup
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+LEFT JOIN pg_stat_user_tables s ON s.relid=c.oid
+WHERE n.nspname='public' AND c.relkind='r'
+ORDER BY pg_total_relation_size(c.oid) DESC LIMIT 20;
+```
+
+Connect from `server/` with the cloud creds: `source .env.secrets.cloud`, then
+`psql -h db-postgresql-nyc3-11231-do-user-8591796-0.m.db.ondigitalocean.com -p 25060 -U doadmin -d defaultdb`
+with `PGSSLMODE=require PGSSLROOTCERT=ca-certificate.crt PGPASSWORD=$DB_PASSWORD`.
+
+### Findings driving the plan
+
+- **`warships_player` TOAST (8.4 GB) is dominated by `battles_json`** — the raw per-ship
+  `ships/stats/` payload, ~10× every other JSON column in a page-level sample, ~24 KB/blob. It exists
+  on **354,204 of 1.03M players**; of those, **141,706 are inactive >90 days** (84,398 stale >180d) —
+  a live ~3 GB prune lever. **The frontend never reads `battles_json`** (grep of `client/app`: 0
+  refs; same for `tiers_json`/`type_json`/`activity_json`/`achievements_json`; only `randoms_json`,
+  `ranked_json`, `efficiency_json` are consumed). Server-side, `battles_json` is still load-bearing:
+  it derives `tiers/type/randoms_json` on write (`data.py:2520-2522`), seeds the battle-history
+  lifetime baseline (`views.py:651`), and the randoms endpoint falls back to `randoms_json` when it
+  is NULL (`views.py:449-453`, fallback verified). It is **refetched fresh every 15 min** on visit
+  (`views.py:321-328`) → any stored copy is **disposable**. 163K dead tuples (~16% of heap) await
+  vacuum.
+- **`warships_battleobservation` (8.5 GB, ~all TOAST) regrew** from the post-VACUUM-FULL 7 GB (2 days
+  earlier) because the daily compactor keeps **`COMPACT_KEEP_PER_PLAYER_DEFAULT = 3`**
+  (`incremental_battles.py:1066`) observations' JSON per player. The diff path consumes **only the
+  single most-recent prior observation** per (player, mode): random diff reads `previous` via
+  `.first()` (`incremental_battles.py:749-754`, `:596`); ranked walk-back returns the first non-NULL
+  match (`:358-403`). So **keep=1 is correct for diff integrity**; keep=3 is ~3× waste. As of
+  measurement, 358K rows still held a random payload and 284K a ranked payload (642K vs the ~137K
+  distinct players → far above the keep=1 baseline).
+- **Dormant rollup tables** `playermonthlyshipstats` (106 MB / ~124K rows) / `playeryearlyshipstats`
+  (64 MB / ~119K rows). **CORRECTION (2026-05-26):** an earlier draft of this runbook called these
+  "empty / writer disabled" — that was **wrong on both counts**, derived from a stale `n_live_tup=0`
+  statistic. The nightly rollup writer **is active** on prod (`BATTLE_HISTORY_ROLLUP_ENABLED=1` lives
+  in `.env.cloud:13`, so every deploy writes it to the live env) and populates these tables. The data
+  is *dormant* — the weekly/monthly/yearly UI pills are hidden (`incremental_battles.py:1303`, commit
+  `7dc7e86`), all live battle-history windows read the intact `PlayerDailyShipStats`
+  (`views.py:516-519`), and `?period=monthly` is a legacy API escape hatch the frontend no longer
+  uses (`views.py:1150-1153`) — but it is **real derived data**, not bloat-only. **Do NOT `TRUNCATE`**
+  to reclaim (that deletes ~243K real rows; it was done in error on 2026-05-26 and recovered by
+  rebuilding from the daily layer — see Execution log). The index bloat is reclaimable losslessly via
+  `REINDEX TABLE` instead.
+- **`playerachievementstat` (1.1 GB; 614 MB indexes > 492 MB heap)** is a denormalized mirror of
+  `Player.achievements_json`, rewritten in lockstep on every refresh (`data.py:540-553`). It is read
+  only by account-merge ops (`player_records.py`), not by any API/view — but the merge read and the
+  unique-constraint index are real, so this is a **Tier-3/future** lever, not a quick win.
+
+## Remediation plan
+
+Tiered by risk × reversibility. Most of Tier 1 is config + ops, not new code — reuse the existing
+`prune_battle_observations` tooling. **Every ad-hoc heavy query / `VACUUM` gets
+`SET LOCAL statement_timeout`** and a `pg_stat_activity` after-check (lesson from the 2026-05-24
+runaway query that pinned a core for 7.6 h: killing the `psql` client does **not** cancel the
+server-side backend — confirm with `pg_cancel_backend(pid)` if needed).
+
+### Tier 1 — Safe, mostly-reversible reclaim (cap growth + headroom)
+
+1. **BattleObservation keep-set 3 → 1.** Append `BATTLE_OBSERVATION_COMPACT_KEEP=1` to
+   `/etc/battlestats-server.env` (the task already reads it — `tasks.py:1603`; default `"3"`), restart
+   `battlestats-beat` + `battlestats-celery-background`. Run the prune live in paced batches until the
+   dry-run reports ~0 candidates:
+   ```
+   python manage.py prune_battle_observations --dry-run --keep-per-player 1
+   python manage.py prune_battle_observations --keep-per-player 1 --batch-size 2000 --sleep 0.5 --max-rows 200000   # repeat
+   ```
+   Then a windowed `VACUUM (FULL, VERBOSE)` on `warships_battleobservation` (heap is only 204 MB →
+   short lock, ~minutes; captures resume right after, as in the 2026-05-24 run). Use
+   `lock_timeout='2min'` + `statement_timeout='20min'` as `doadmin`. **Est. ~4-5 GB to OS.** Safe:
+   diff path needs only keep=1.
+
+2. **REINDEX the dormant rollup tables — do NOT truncate.** `REINDEX TABLE
+   warships_playermonthlyshipstats; REINDEX TABLE warships_playeryearlyshipstats;` reclaims the index
+   bloat (the bulk of their ~170 MB) **without deleting the ~243K real, writer-maintained rows**.
+   Truncating these deletes derived data that the active nightly rollup will only partially refill
+   (it rebuilds the current period, not history); full recovery requires rebuilding every
+   month/year from the daily layer (see Execution log, 2026-05-26). Reclaim is modest (~120-150 MB
+   of index space) and lossless.
+
+3. **Prune `battles_json` for inactive players (new mgmt command).** Mirror the
+   `prune_battle_observations` shape (`--dry-run`, `--batch-size`, `--sleep`, `--max-rows`,
+   `SET LOCAL statement_timeout`). NULL **only** `battles_json` (keep the small derived
+   `tiers/type/randoms_json`) for `is_hidden=false AND last_battle_date < now()-INTERVAL '180 days'`
+   (start at 180d conservative ≈ 84K rows; can tighten to 90d ≈ 142K rows later). **Reversible** —
+   refetched on next visit (`views.py:321`); randoms endpoint already falls back to `randoms_json`
+   (`views.py:451-453`); battle-history for a >180d-inactive player is empty anyway. Follow with a
+   **regular `VACUUM`** so freed TOAST returns to reusable. **Est. ~2 GB at 180d.**
+
+4. **Drop unused JSON from the player wire payload.** Replace `PlayerSerializer`'s
+   `fields = '__all__'` (`serializers.py:102`) with an explicit field list that **omits
+   `battles_json`, `tiers_json`, `type_json`, `activity_json`, `achievements_json`** (frontend reads
+   none of them). **0 GB on disk**, but trims ~24 KB/player-page off the wire **and** off the
+   Redis-cached `get_cached_player_detail` dict — easing the 3 GB `allkeys-lru` cache. This is an
+   **API contract change**: per team-doctrine rule 5, update the data-product contract test
+   (`test_data_product_contracts.py`) + any contract doc in the same commit. Verified safe
+   server-side: every server read of these fields reads from the model, not the serialized dict
+   (derivations at `data.py:2520-2522`, baseline at `views.py:651`, summary `build_player_summary`).
+
+5. **Regular `VACUUM (ANALYZE)`** the dead-tuple tables — `warships_player` (163K),
+   `playerachievementstat` (151K), `playerdailyshipstats` (151K), `snapshot` (58K), `clan` (23K).
+   0 GB to OS but halts reusable-space drift and refreshes planner stats (perf).
+
+### Tier 2 — Measure, then tune (the performance half)
+
+6. **Decide `warships_player` heap reclaim by measurement, not reflex.** `pgstattuple` is **not**
+   installed (only `pg_stat_statements`); `CREATE EXTENSION pgstattuple;` (contrib, DO-supported) and
+   measure true bloat **after** the Tier-1 prune. `VACUUM FULL` on the 11 GB hot table takes an
+   `ACCESS EXCLUSIVE` lock (write outage for minutes) — only run it in a maintenance window **if**
+   pgstattuple shows large reclaimable bloat. Otherwise prefer **per-table autovacuum tuning**
+   (lower `autovacuum_vacuum_scale_factor` / `analyze_scale_factor` on the top-5 churn tables) so
+   reusable space is held without a locking rewrite. Prior note: a blind `VACUUM FULL` here was
+   explicitly deferred on 2026-05-24 pending this measurement.
+
+### Out of scope (do not attempt under this runbook)
+
+- **DO cluster downsize / dump→restore migration** — storage can't shrink in place; separate project.
+- **Structural `battles_json` refactor** (move the lifetime baseline into a compact per-ship table so
+  the raw blob can be dropped entirely) — possible future runbook.
+- **`playerachievementstat` de-duplication** — read by merge ops; Tier-3/future.
+
+## Realistic reclaim ceiling (set expectations honestly)
+
+~**5-7 GB returned to OS headroom**: observation keep-1 ~4-5 GB + empties ~170 MB + inactive
+`battles_json` prune ~2 GB — **plus** growth capped and a lighter wire/Redis payload. The DO bill and
+the 60 GB allocation do **not** change.
+
+## Critical files
+
+- `server/warships/incremental_battles.py` — `compact_battle_observation_payloads()`,
+  `COMPACT_KEEP_PER_PLAYER_DEFAULT` (`:1066`), diff path (`:596`, `:749-754`, `:358-403`),
+  rollup gate (`:1299-1308`).
+- `server/warships/management/commands/prune_battle_observations.py` — shape to mirror for the new
+  `prune_player_battles_json` (inactive-prune) command; `--keep-per-player` etc. (`:57-97`).
+- `server/warships/tasks.py:1573-1619` (prune task + env reads incl. `:1603`), `:1532-1569` (rollup
+  gate `:1539`).
+- `server/warships/data.py:2518-2522` (battles_json write + derivations), `:540-553` (achievements
+  lockstep write).
+- `server/warships/views.py:321-328` (refetch trigger), `:449-453` (randoms `randoms_json` fallback),
+  `:651` (battle-history lifetime baseline).
+- `server/warships/serializers.py:80-107` (`PlayerSerializer` wire-trim, `fields='__all__'` at `:102`).
+- `server/warships/signals.py:570-586` (`prune-battle-observations` Beat entry).
+
+## Verification (run when executing — not part of authoring this runbook)
+
+- **Before/after sizing:** the per-table `pg_total_relation_size` query above + `pg_database_size`.
+- **Diff integrity after keep=1:** confirm new `BattleEvent` rows keep appearing post-compaction for a
+  sample active player (the diff only needs the latest observation).
+- **Wire-trim safety:** backend `test_data_product_contracts.py` + frontend `npm test` green; load a
+  player page in the app and confirm all charts render (dedicated endpoints / `randoms_json`).
+- **Inactive-prune reversibility:** visit a pruned >180d-inactive player → `battles_json` refetches
+  and the page hydrates within the 15-min refresh path.
+- **No runaway backend after every `VACUUM`/prune:**
+  `SELECT pid, now()-query_start AS age, state, left(query,80) FROM pg_stat_activity WHERE state='active' ORDER BY age DESC;`
+
+## Execution log — 2026-05-26
+
+Partial execution this session (user-authorized). Result: **`defaultdb` 24 GB → 19 GB.**
+
+**Done:**
+- **Compaction env durability fixed + LIVE.** Root cause of the battleobservation regrowth found: the
+  deploy script overwrites `/etc/battlestats-server.env` from `.env.cloud` on every deploy, so the
+  hand-added `BATTLE_OBSERVATION_COMPACT_ENABLED=1` (2026-05-24) was wiped → the daily compactor had
+  been **off**. Added `BATTLE_OBSERVATION_COMPACT_ENABLED=1` + `BATTLE_OBSERVATION_COMPACT_KEEP=1` to
+  `server/.env.cloud` (`.env.cloud` is gitignored — the deploy reads the working-tree copy). **Backend
+  deployed** (release `20260526113530`); `post_migrate` re-enabled the `prune-battle-observations`
+  Beat task (verified `enabled=t`, cron 12:30 UTC) and the live env now carries the vars → the daily
+  keep=1 compactor is active and durable.
+- **keep=1 prune + VACUUM FULL.** Verified keep=1 diff-safety by reading the diff path directly
+  (`record_observation_from_payloads` reads only the single latest prior; compactor preserves
+  latest-random + latest-ranked). Dry-run: 233,496 payloads / 82,783 players. Ran live
+  (`--keep-per-player 1 --batch-size 2000 --sleep 0.5`): JSON rows 664K → **200,930** (random
+  369K→201K, ranked 295K→143K). `VACUUM (FULL, ANALYZE)`: **8,919 MB → 4,231 MB** (~4.7 GB to OS),
+  4 min, captures resumed.
+- **Inactive `battles_json` prune.** Batched server-side UPDATE (5K/txn, paced, `statement_timeout`)
+  NULLing only `battles_json` (derived cols kept) for ~84,398 non-hidden players with
+  `last_battle_date` >180d stale → 0 remaining. Reversible (refetched on visit; randoms endpoint
+  falls back to `randoms_json`). Followed by `VACUUM (ANALYZE)` → space is now **reusable** within
+  `warships_player` (growth capped); ~2 GB to OS still needs a windowed `VACUUM FULL` (Tier 2).
+- **`VACUUM (ANALYZE)`** of dead-tuple tables: `warships_player` 163K→1K dead, `playerachievementstat`
+  199K→1.2K, `snapshot` 58K→278, `playerexplorersummary` 46K→120, `clan` 23K→3. Planner stats refreshed.
+- REINDEX of the rollup tables was **not needed** — the (erroneous) TRUNCATE + clean reinsert already
+  produced fresh, unbloated indexes.
+
+**Net result: `defaultdb` 24 GB → 19 GB (~5 GB to OS); growth now capped by the live keep=1 compactor.**
+
+**INCIDENT — erroneous TRUNCATE + recovery.** Acting on this runbook's (now-corrected) "empty rollup
+tables" step, ran `TRUNCATE warships_playermonthlyshipstats, warships_playeryearlyshipstats` — but
+they held **123,745 / 119,254 real rows** (the `n_live_tup=0` stat was stale; the count printed in the
+same script but the TRUNCATE was bundled into the same command, so there was no chance to react).
+**Lesson: a destructive op and its pre-check must be SEPARATE tool calls.** Impact was **zero
+user-visible** (period UI pills hidden, `incremental_battles.py:1303`; all live windows read daily).
+Recovered by rebuilding from the intact daily layer. The codebase function
+`rebuild_period_rollups_for_date` **OOM-killed** (7.2 GB RSS) on the memory-constrained droplet — it
+loads a full period's daily rows into a Python dict — so recovery used a server-side SQL `GROUP BY`
+aggregation instead (memory-safe, seconds). Restored: April 8,784 / **May 617,681** / **yearly-2026
+620,308** rows; cross-check passed (monthly≈yearly≈daily random battles ≈ 2,842,600, within 25 of
+each other from live writes). The restored data is *more complete* than pre-truncate (123K was
+partial → see next).
+
+**NEW ISSUE surfaced — nightly rollup OOM.** Because `rebuild_period_rollups_for_date` OOMs on full
+months/years at the current daily-table scale, the nightly `roll_up_player_daily_ship_stats_task` has
+likely been **silently failing** on the monthly/yearly tiers (explains the partial 123K/119K
+pre-truncate counts). Fix is a separate task: rewrite the period aggregation as server-side SQL
+(`INSERT … SELECT … GROUP BY`) instead of a Python row-load. Tracked as a follow-up.
+
+**Remaining follow-ups (deferred):**
+- **`PlayerSerializer` wire-trim** (Tier 1 step 4) — a code PR with a contract-test update; skipped
+  this session.
+- **Tier 2 — `warships_player` OS reclaim:** `CREATE EXTENSION pgstattuple`, measure true bloat, then
+  a **windowed** `VACUUM FULL warships_player` (ACCESS EXCLUSIVE on the 11 GB hot table) to return the
+  pruned `battles_json` ~2 GB to the OS — or tune per-table autovacuum scale factors instead.
+- **Nightly-rollup OOM fix** — rewrite `rebuild_period_rollups_for_date` as server-side SQL so the
+  monthly/yearly tiers stop silently failing (see incident note above).
+
+## Related
+
+- `runbook-db-cpu-saturation-2026-05-24.md` — the parent incident (CPU axis resolved; disk axis →
+  this runbook). The daily BattleObservation compactor (`BATTLE_OBSERVATION_COMPACT_ENABLED=1`) and
+  the one-time `VACUUM FULL` from that session are already in place.
+- `runbook-battle-history-rollout-2026-04-28.md` / `runbook-ranked-battle-history-rollout-2026-05-02.md`
+  — origin of the BattleObservation capture that drives both bloat sources.

--- a/server/warships/data.py
+++ b/server/warships/data.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone, timedelta, date
 import logging
 import math
 import os
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -5380,6 +5381,18 @@ BEST_CLAN_SORTS = ('overall', 'wr')
 # See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md (CPU axis).
 SCORE_BEST_CLANS_CACHE_TTL = int(
     os.environ.get('SCORE_BEST_CLANS_CACHE_TTL', 3 * 60 * 60))
+# Single-flight lock so a cold/expired cache can't let concurrent callers
+# (landing warm, bulk loader, cold-start request) all run the heavy
+# 3-aggregate scan at once — the cache-stampede behind the 2026-05-26
+# post-VACUUM-FULL CPU spike. LOCK_TIMEOUT must exceed the worst-case compute
+# (cold-cache ~3 min) so the leader's lock can't expire mid-compute and admit a
+# second leader. LOCK_WAIT is how long a non-leader waits for the leader to
+# publish the cache before computing itself (covers the warm ~15-18s compute;
+# bounded so a pathologically slow leader can't hang the caller indefinitely).
+SCORE_BEST_CLANS_LOCK_TIMEOUT = int(
+    os.environ.get('SCORE_BEST_CLANS_LOCK_TIMEOUT', 5 * 60))
+SCORE_BEST_CLANS_LOCK_WAIT = int(
+    os.environ.get('SCORE_BEST_CLANS_LOCK_WAIT', 30))
 
 
 def _minmax_normalize(values: list[float]) -> list[float]:
@@ -5583,6 +5596,24 @@ def score_best_clans(limit: int = BULK_CACHE_CLAN_MEMBER_CLANS, realm: str = DEF
         cached_ids, cached_metrics = cached
         return list(cached_ids[:limit]), cached_metrics
 
+    # Single-flight: only one caller computes a given (realm, sort) at a time;
+    # others wait for it to publish the cache rather than running the same heavy
+    # scan concurrently (the cold-cache stampede behind the 2026-05-26 spike).
+    # See SCORE_BEST_CLANS_LOCK_* above.
+    lock_key = f'{cache_key}:lock'
+    have_score_lock = cache.add(lock_key, 1, SCORE_BEST_CLANS_LOCK_TIMEOUT)
+    if not have_score_lock:
+        wait_deadline = time.monotonic() + SCORE_BEST_CLANS_LOCK_WAIT
+        while time.monotonic() < wait_deadline:
+            time.sleep(0.5)
+            cached = cache.get(cache_key)
+            if cached is not None:
+                cached_ids, cached_metrics = cached
+                return list(cached_ids[:limit]), cached_metrics
+        # Leader still computing (rare cold path) — compute ourselves rather
+        # than block the caller any longer. have_score_lock stays False so we
+        # never release a lock we don't own (the leader's auto-expires).
+
     now = django_timezone.now()
 
     # Hard filters via ORM annotation
@@ -5617,6 +5648,8 @@ def score_best_clans(limit: int = BULK_CACHE_CLAN_MEMBER_CLANS, realm: str = DEF
     if not candidates:
         logging.warning(
             "score_best_clans: no clans passed hard filters for sort=%s", normalized_sort)
+        if have_score_lock:
+            cache.delete(lock_key)
         return [], {}
 
     clan_ids = [int(row['clan_id']) for row in candidates]
@@ -5805,6 +5838,8 @@ def score_best_clans(limit: int = BULK_CACHE_CLAN_MEMBER_CLANS, realm: str = DEF
     # limits — reuses this computation until the TTL lapses.
     cache.set(cache_key, (all_clan_ids, cb_metrics_by_clan),
               SCORE_BEST_CLANS_CACHE_TTL)
+    if have_score_lock:
+        cache.delete(lock_key)
 
     if all_clan_ids:
         logging.info(

--- a/server/warships/incremental_battles.py
+++ b/server/warships/incremental_battles.py
@@ -1000,6 +1000,15 @@ def rebuild_daily_ship_stats_for_date(target_date) -> Dict[str, Any]:
             date=target_date,
         ).delete()
 
+        # NOTE: this loads one calendar day of BattleEvent rows into Python
+        # (~40K today — safe). It is the SAME unbounded-Python-load anti-pattern
+        # that OOM-killed _aggregate_into_period_table on full periods
+        # (rewritten to DB-side aggregation 2026-05-26). A single day stays
+        # small, but a multi-day backfill via rebuild_player_daily_ship_stats
+        # would hit the same wall. TODO(2026-Q3): if BattleEvent grows past
+        # ~200K/day or backfills span many days, rewrite this as a DB-side
+        # values().annotate() group-by (Count(filter=survived) for survived,
+        # grouped by player/ship/mode/season_id) like the period aggregator.
         events = BattleEvent.objects.filter(
             detected_at__date=target_date,
         ).order_by("detected_at")
@@ -1291,6 +1300,8 @@ def _aggregate_into_period_table(
     `PlayerMonthlyShipStats`, `PlayerYearlyShipStats` — they share the
     same column shape via the abstract base.
     """
+    from django.db.models import Max, Min, Sum
+
     from warships.models import PlayerDailyShipStats
 
     with transaction.atomic():
@@ -1302,52 +1313,68 @@ def _aggregate_into_period_table(
         # over-count by summing random + ranked rows together. The
         # weekly/monthly/yearly UI pills are currently hidden (commit
         # 7dc7e86) so this deferral has no user-visible impact.
-        daily_qs = PlayerDailyShipStats.objects.filter(
-            date__gte=target_period_start, date__lte=period_end_inclusive,
-            mode=PlayerDailyShipStats.MODE_RANDOM,
-        ).order_by("date")
+        #
+        # Aggregate in the DATABASE (GROUP BY player_id, ship_id) and stream
+        # the grouped rows in batches. The earlier version pulled every daily
+        # row in the window into a Python dict — for a month/year that is
+        # ~1.1-1.2M rows and OOM-killed the worker on 2026-05-26 (7.2 GB RSS),
+        # silently breaking the nightly monthly/yearly rollup. Now only the
+        # grouped result is materialised, bounded by the bulk_create batch.
+        # `ship_name=Max(...)` returns a non-empty name when one exists ('' < any).
+        aggregated = (
+            PlayerDailyShipStats.objects
+            .filter(
+                date__gte=target_period_start,
+                date__lte=period_end_inclusive,
+                mode=PlayerDailyShipStats.MODE_RANDOM,
+            )
+            .values("player_id", "ship_id")
+            .annotate(
+                t_battles=Sum("battles"),
+                t_wins=Sum("wins"),
+                t_losses=Sum("losses"),
+                t_frags=Sum("frags"),
+                t_damage=Sum("damage"),
+                t_xp=Sum("xp"),
+                t_planes_killed=Sum("planes_killed"),
+                t_survived_battles=Sum("survived_battles"),
+                t_first_event_at=Min("first_event_at"),
+                t_last_event_at=Max("last_event_at"),
+                t_ship_name=Max("ship_name"),
+            )
+            .order_by()
+        )
 
-        rows: Dict[tuple, Dict[str, Any]] = {}
-        for d in daily_qs:
-            key = (d.player_id, d.ship_id)
-            row = rows.get(key)
-            if row is None:
-                row = {
-                    "player_id": d.player_id,
-                    "period_start": target_period_start,
-                    "ship_id": d.ship_id,
-                    "ship_name": d.ship_name or "",
-                    "battles": 0, "wins": 0, "losses": 0, "frags": 0,
-                    "damage": 0, "xp": 0, "planes_killed": 0,
-                    "survived_battles": 0,
-                    "first_event_at": d.first_event_at,
-                    "last_event_at": d.last_event_at,
-                }
-                rows[key] = row
-            row["battles"] += d.battles
-            row["wins"] += d.wins
-            row["losses"] += d.losses
-            row["frags"] += d.frags
-            row["damage"] += d.damage
-            row["xp"] += d.xp
-            row["planes_killed"] += d.planes_killed
-            row["survived_battles"] += d.survived_battles
-            if d.first_event_at and (row["first_event_at"] is None
-                                     or d.first_event_at < row["first_event_at"]):
-                row["first_event_at"] = d.first_event_at
-            if d.last_event_at and (row["last_event_at"] is None
-                                    or d.last_event_at > row["last_event_at"]):
-                row["last_event_at"] = d.last_event_at
-            if d.ship_name and not row["ship_name"]:
-                row["ship_name"] = d.ship_name
-
-        if rows:
-            period_table.objects.bulk_create([
-                period_table(**row) for row in rows.values()
-            ])
+        batch_size = 5000
+        batch: list = []
+        written = 0
+        for r in aggregated.iterator(chunk_size=batch_size):
+            batch.append(period_table(
+                player_id=r["player_id"],
+                period_start=target_period_start,
+                ship_id=r["ship_id"],
+                ship_name=r["t_ship_name"] or "",
+                battles=r["t_battles"] or 0,
+                wins=r["t_wins"] or 0,
+                losses=r["t_losses"] or 0,
+                frags=r["t_frags"] or 0,
+                damage=r["t_damage"] or 0,
+                xp=r["t_xp"] or 0,
+                planes_killed=r["t_planes_killed"] or 0,
+                survived_battles=r["t_survived_battles"] or 0,
+                first_event_at=r["t_first_event_at"],
+                last_event_at=r["t_last_event_at"],
+            ))
+            if len(batch) >= batch_size:
+                period_table.objects.bulk_create(batch)
+                written += len(batch)
+                batch = []
+        if batch:
+            period_table.objects.bulk_create(batch)
+            written += len(batch)
 
     return {
-        "rows_written": len(rows),
+        "rows_written": written,
         "period_start": str(target_period_start),
     }
 

--- a/server/warships/serializers.py
+++ b/server/warships/serializers.py
@@ -99,7 +99,20 @@ class PlayerSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Player
-        fields = '__all__'
+        # Trim JSON columns the frontend never reads from the detail payload
+        # (grep of client/app: 0 refs) — they bloated every /api/players/<name>
+        # response and the Redis get_cached_player_detail dict by ~24 KB/player
+        # for no consumer. Server-side reads of battles_json (landing .values(),
+        # get_kill_ratio, battle-history baseline, randoms fallback) use the
+        # MODEL attribute, unaffected by the serialized field set. randoms_json,
+        # ranked_json and efficiency_json ARE consumed by the client, so they
+        # stay. This serializer is not ODCS-contract-governed (the contracts
+        # cover PlayerSummary/PlayerExplorerRow). See
+        # agents/runbooks/runbook-db-optimization-followups-2026-05-26.md (FU-2).
+        exclude = [
+            'battles_json', 'tiers_json', 'type_json',
+            'activity_json', 'achievements_json',
+        ]
         extra_kwargs = {
             'pvp_frags': {'write_only': True},
             'pvp_survived_battles': {'write_only': True},

--- a/server/warships/tests/test_landing.py
+++ b/server/warships/tests/test_landing.py
@@ -593,6 +593,51 @@ class LandingHelperTests(TestCase):
         fresh_ids, _ = score_best_clans(sort='overall')
         self.assertNotIn(8201, fresh_ids)
 
+    def test_score_best_clans_single_flight_lock(self):
+        # Single-flight guard for the 2026-05-26 post-VACUUM cold-cache
+        # stampede: a leader releases its lock after publishing, and a
+        # non-leader that times out waiting falls through to compute a correct
+        # ranking (never blocks forever, never returns degraded).
+        # See runbook-db-optimization-followups / runbook-db-cpu-saturation.
+        from warships.models import DEFAULT_REALM
+        now = timezone.now()
+        clan = Clan.objects.create(
+            clan_id=8202, name='LockClan', tag='LK', members_count=12,
+            cached_clan_wr=59.0, cached_total_battles=320000,
+            cached_active_member_count=10,
+        )
+        for index in range(5):
+            player = Player.objects.create(
+                name=f'LockClanP{index}', player_id=820200 + index, clan=clan,
+                pvp_battles=5000, pvp_wins=2800, days_since_last_battle=3,
+            )
+            PlayerExplorerSummary.objects.create(
+                player=player, player_score=8.5,
+                clan_battle_total_battles=15, clan_battle_overall_win_rate=56.0,
+                clan_battle_summary_updated_at=now - timedelta(days=30),
+            )
+
+        cache_key = realm_cache_key(
+            DEFAULT_REALM, 'best-clans:scored:v1:overall')
+        lock_key = f'{cache_key}:lock'
+
+        # Leader path: a normal call computes, caches, and RELEASES the lock.
+        cache.clear()
+        leader_ids, _ = score_best_clans(sort='overall')
+        self.assertIn(8202, leader_ids)
+        self.assertIsNone(cache.get(lock_key))
+
+        # Waiter fall-through: a stuck leader holds the lock with an empty
+        # cache. With the wait window collapsed to 0 the caller does not block;
+        # it falls through, computes a correct ranking, and (not owning the
+        # lock) leaves it intact for the leader's TTL to clear.
+        cache.clear()
+        self.assertTrue(cache.add(lock_key, 1, 300))
+        with patch('warships.data.SCORE_BEST_CLANS_LOCK_WAIT', 0):
+            waiter_ids, _ = score_best_clans(sort='overall')
+        self.assertIn(8202, waiter_ids)
+        self.assertEqual(cache.get(lock_key), 1)
+
     def test_queue_landing_republish_debounces_within_cooldown(self):
         # Regression guard for the background-queue flood: bursts of clan/player
         # invalidations must coalesce into at most one warm per realm within the


### PR DESCRIPTION
## Summary

Two stacked DB-efficiency efforts. Net: **`defaultdb` 24 GB → 16 GB (~8 GB returned to OS)**, growth capped, and a silently-failing nightly rollup fixed. All changes deployed to prod and verified; this PR lands the code + the durable runbooks.

### `24c0159` — size optimization (runbook authored + executed)
- **BattleObservation keep=1 prune + VACUUM FULL:** 8.9 → 4.2 GB. The diff path only needs the single latest prior observation per (player, mode), so keep=3 was ~3× waste (verified by reading the diff path).
- **Inactive (>180d) `battles_json` prune** (~84K players) + VACUUM → space reusable, growth capped.
- **Root cause of regrowth:** the deploy overwrites the live env from `.env.cloud`, which lacked the compaction vars (the 2026-05-24 hand-edit was wiped). Now durable in `.env.cloud`; the daily `prune-battle-observations` Beat task is live (keep=1).
- Runbook `runbook-db-size-optimization-2026-05-26` (also records an erroneous TRUNCATE of the dormant monthly/yearly rollup tables — recovered from the daily layer, zero user impact).

### `caf3040` — follow-ups
- **FU-1 — nightly-rollup OOM fix:** `_aggregate_into_period_table` rewritten to aggregate in the database (`values().annotate()` GROUP BY, streamed bulk_create) instead of loading a full month/year of `PlayerDailyShipStats` into Python. That load OOM-killed the worker (7.2 GB) and had been silently breaking the monthly/yearly rollup. Behaviour-preserving; memory bounded by batch. Smoke-tested on the droplet: yearly rebuild 622,942 rows, memory flat. (Daily rebuild has the same pattern but is safe at ~1 day of events — `TODO` added.)
- **FU-2 — player-detail wire-trim:** `PlayerSerializer` excludes `battles_json`/`tiers_json`/`type_json`/`activity_json`/`achievements_json` — the frontend reads none of them (0 refs); server-side reads use the model attribute; not ODCS-contract-governed. Shrinks the wire + Redis cache ~24 KB/player.
- **FU-3 — `VACUUM FULL warships_player`** (run in a confirmed window): pgstattuple heap 45.8% free + TOAST 34% free → 11 → 7.4 GB.
- Runbook `runbook-db-optimization-followups-2026-05-26`.

## Test plan
- Lean backend release gate + `test_incremental_battles.py` (rollup coverage) + `test_data_product_contracts.py`: **377 passed** (sqlite).
- Deployed to prod (release `20260526125032`); homepage + API 200; FU-1 smoke-tested on the droplet against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)