### PR TITLE
fix(player): stop live-update reload loop (re-hydrate once on refresh land)

### DIFF
--- a/client/app/components/usePlayerLiveRefresh.ts
+++ b/client/app/components/usePlayerLiveRefresh.ts
@@ -9,8 +9,10 @@ import type { PlayerData } from './entityTypes';
 export const PLAYER_REFRESH_PENDING_HEADER = 'X-Player-Refresh-Pending';
 export const PLAYER_NEXT_REFRESH_HEADER = 'X-Player-Next-Refresh';
 
-const POLL_INTERVAL_MS = 5_000;
-const POLL_LIMIT = 24; // ~2 min ceiling so a slow/failed refresh can't poll forever
+const POLL_INTERVAL_MS = 6_000;
+const POLL_LIMIT = 30; // ~3 min ceiling — long enough to catch a queued refresh,
+// bounded so a slow/failed one can't poll forever. Polls are lightweight header
+// checks; the page only re-hydrates ONCE, when the refresh actually lands.
 
 export type LiveRefreshPhase = 'loading' | 'cooldown';
 
@@ -99,18 +101,30 @@ export const usePlayerLiveRefresh = ({
                 );
                 if (cancelled) return;
 
-                onRehydrateRef.current(data);
-                setRefreshNonce((nonce) => nonce + 1);
-
                 const stillPending = parsePendingHeader(headers[PLAYER_REFRESH_PENDING_HEADER]);
                 const next = parseNextRefreshHeader(headers[PLAYER_NEXT_REFRESH_HEADER]);
-                if (next !== null) {
-                    setNextRefresh(next);
+
+                if (!stillPending) {
+                    // Refresh landed — re-hydrate exactly ONCE (swap in fresh data,
+                    // bump the nonce so charts re-fetch a single time) and settle
+                    // into the cooldown countdown. Re-hydrating on every interim
+                    // poll is what caused the "loads repeatedly" loop.
+                    onRehydrateRef.current(data);
+                    setRefreshNonce((nonce) => nonce + 1);
+                    if (next !== null) setNextRefresh(next);
+                    setPending(false);
+                    setSecondsRemaining(computeSecondsRemaining(next));
+                    return;
                 }
 
-                if (stillPending && attempt < POLL_LIMIT) {
+                if (attempt < POLL_LIMIT) {
+                    // Still refreshing — keep checking the header, but do NOT touch
+                    // playerData/refreshNonce (no re-render storm, no chart reloads).
                     timer = setTimeout(poll, POLL_INTERVAL_MS);
                 } else {
+                    // Gave up waiting — stop the spinner without forcing a reload;
+                    // the countdown reflects whatever freshness we have.
+                    if (next !== null) setNextRefresh(next);
                     setPending(false);
                     setSecondsRemaining(computeSecondsRemaining(next));
                 }


### PR DESCRIPTION
## Problem
The visit-refresh poll (`usePlayerLiveRefresh`) called `onRehydrate` + bumped `refreshNonce` on **every** 5s poll, so the header + all charts re-fetched repeatedly for the whole poll window whenever `battles_updated_at` was stale — i.e. any cold player whose visit-triggered refresh is queued for 1–3 min. Reported as a page that "loads repeatedly" (`agster123`).

## Fix
Re-hydrate **once**, only when `X-Player-Refresh-Pending` flips false. Interim polls are lightweight header checks that never touch render state. Poll window widened to ~3 min (6s × 30) so a queued refresh is actually caught.

Backend confirmed healthy (refresh completes within minutes; 0/13 recently-visited players stale) — this was purely client poll behavior.

## Test
Affected jest suites + tsc pass. Follow-up: a renderHook fake-timer test asserting re-hydrate fires once on pending-clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)