### PR TITLE
perf(landing): stop crawl-driven republish from rebuilding recent-players (DB CPU)

### DIFF
--- a/agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md
+++ b/agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md
@@ -257,3 +257,22 @@ Architecture: Django + Celery, Postgres + Redis + RabbitMQ, three Celery workers
 - **Still open:** does `score_best_clans()`'s ~2,180/day call rate trace to genuine user traffic on the Best-clan homepage, or to `LANDING_CLANS_DIRTY_KEY` thrashing forcing recompute on most requests? Confirm before/while implementing the cache fix.
 - Which specific periodic task (if any) owns the 03:00 and 23:00 UTC peaks? (The crawl at `CLAN_CRAWL_SCHEDULE_HOUR=3` and overnight rollups remain candidates for a *second* CPU contributor distinct from the score_best_clans daytime load — verify by sampling `pg_stat_activity` during a 03:00 episode.)
 - Is the 770-min May 3 episode a stuck/zombie worker (cf. `runbook-incident-celery-zombie-worker-2026-04-12.md`) rather than steady load?
+
+## Recurrence + fix — 2026-05-27 (the recent-players republish leg)
+
+A fresh "CPU 90%+ since ~23:00 UTC" report. Re-diagnosed from the cluster directly (DO Prometheus metrics endpoint — basic-auth creds from `GET /v2/databases/{id}/metrics/credentials`, scrape `https://<db-host>:9273/metrics`):
+
+- **CONFIRMED the saturation this time** (the 2026-05-24 number was trusted from the user): instantaneous CPU was only ~22% busy when sampled, but **`system_load1=1.27 / load5=3.22 / load15=4.38` on a 1-vCPU node** — run queue ~4 deep, i.e. genuine 15-min saturation that was already receding. Mem 60%, disk 38% — both fine. `pg_stat_activity` showed **0 active client backends** across 6 samples → the load was bursty periodic work between samples, not one long query (the trap that nearly sent this down the "crawl writes are the driver" path — they are not).
+- **Driver: the landing republish warm storm via the recent-players leg.** `warm_landing_page_content_task` ran **~20×/40min (~every 2 min) at 13–83s each**. The multi-day ASIA `crawl_all_clans_task` re-dirties the landing clan cache continuously; the 120s `LANDING_REPUBLISH_COOLDOWN_SECONDS` floor let a republish through every ~2 min, and each one ran `warm_landing_page_content(force_refresh=True, include_recent=True)` — **force-rebuilding the recent-*players* 7-day rollup (the 25s `week_battles` `PlayerDailyShipStats` SUM) even though only clan data changed.** ~20 rebuilds/40min on one core ≈ the saturation. At 23:00 the ASIA periodic cluster (recent-players warmer; observation-floor → 9 `update_battle_data`; ranked refresh) stacked on top and tipped it >90%.
+- This is exactly **fix-direction #2/#3** from the CPU-axis findings above, never shipped in the 2026-05-25 remediation (only #1, the `score_best_clans` cache, landed — and it held: that fingerprint's calls dropped 12,443→1,707).
+- **Red herring ruled out:** `enrich_player_data_task` was firing ~1,190/hr (loud in logs) — the known defer-before-lock fan-out during a crawl (`background-unacked-enrichment-deferral`). It is Redis-only, ~3ms/call, **near-zero DB cost** — not the CPU driver. Separate queue-hygiene bug (defer block at `tasks.py` runs before the lock); track as its own PR.
+
+**Fix shipped (v1.13.2):**
+1. `queue_landing_page_warm(realm, include_recent=True)` is now parameterized; `_queue_landing_republish` calls it with **`include_recent=False`** (`tasks.py` / `landing.py`). Clan/player writes no longer rebuild the recent surfaces — those are owned by the dedicated beat warmers (`recent-players-warmer-{realm}` every 3h) and the 55-min landing warmer (which dispatches the task directly with `include_recent=True`, unaffected).
+2. `LANDING_REPUBLISH_COOLDOWN_SECONDS` default **120 → 600** (and set durably in `server/.env.cloud`) — caps crawl-driven republishes at ~6/hr.
+3. Tests: 4 invalidation/fallback dispatch assertions updated to `include_recent=False`; new `test_queue_landing_republish_excludes_recent_surfaces`. Full backend release gate (251 tests) green.
+
+**Still open / follow-ups:**
+- The republish warm still force-refreshes `players_best_*` + `players_popular` (cheaper than `week_battles`, but a clan write shouldn't touch player surfaces at all). A "clan-surfaces-only" republish is the deeper slice if CPU is still elevated after this lands.
+- **Resize question** (1→2 vCPU) deferred per user: ship this fix, watch a full ASIA crawl cycle, then revisit. 209 CPU episodes/24 days says 1 vCPU is near its ceiling regardless.
+- Enrichment defer-before-lock fan-out: separate PR.

--- a/server/warships/landing.py
+++ b/server/warships/landing.py
@@ -139,8 +139,12 @@ LANDING_RECENT_CLANS_DIRTY_KEY = 'landing:recent_clans:dirty:v1'
 # per window per realm. The scheduled beat warmer (LANDING_PAGE_WARM_MINUTES)
 # is unaffected — it dispatches the task directly, not via this path.
 # See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+# Raised 120s -> 600s on 2026-05-27: a multi-day clan crawl re-dirties the
+# cache continuously, so the 120s floor still let ~30 republish warms/hour
+# through; 600s caps that at ~6/hr while the 55-min beat warmer guarantees
+# steady-state freshness. See runbook-db-cpu-saturation-2026-05-24.md.
 LANDING_REPUBLISH_COOLDOWN_SECONDS = int(
-    os.environ.get('LANDING_REPUBLISH_COOLDOWN_SECONDS', '120'))
+    os.environ.get('LANDING_REPUBLISH_COOLDOWN_SECONDS', '600'))
 LANDING_REPUBLISH_COOLDOWN_KEY = 'landing:republish:cooldown:v1'
 LANDING_CLAN_FEATURED_COUNT = 30
 LANDING_CLAN_MIN_TOTAL_BATTLES = 100000
@@ -606,7 +610,13 @@ def _queue_landing_republish(realm: str = DEFAULT_REALM) -> None:
         if not cache.add(cooldown_key, '1', LANDING_REPUBLISH_COOLDOWN_SECONDS):
             return
 
-    queue_landing_page_warm(realm=realm)
+    # include_recent=False: invalidation comes from clan/player writes, which
+    # do not change the recent-players 7-day rollup. Rebuilding it here re-runs
+    # the 25s `week_battles` aggregate on every crawl-driven republish — the
+    # 2026-05-27 DB-CPU saturation. The recent surfaces are kept fresh by their
+    # dedicated beat warmers (recent-players-warmer / the 55-min landing warmer
+    # which dispatches the task directly with include_recent=True).
+    queue_landing_page_warm(realm=realm, include_recent=False)
 
 
 def _publish_landing_payload(

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -246,12 +246,20 @@ def is_clan_battle_summary_refresh_pending(clan_id: object, realm: str = DEFAULT
     return bool(cache.get(_clan_battle_summary_refresh_dispatch_key(clan_id, realm=realm)))
 
 
-def queue_landing_page_warm(realm: str = DEFAULT_REALM):
+def queue_landing_page_warm(realm: str = DEFAULT_REALM, include_recent: bool = True):
     # If a warm is already executing for this realm, skip enqueue. The 30s
     # dispatch dedup expires while the 1200s task runs, so without this gate,
     # cache-fallback paths invoked from inside the warm itself would re-enqueue
     # in a loop (root cause of the 4581-message background-queue pileup
     # observed on 2026-04-27).
+    #
+    # `include_recent=False` is used by the invalidation-driven republish path
+    # (clan/player writes). Those writes don't change the recent-players 7-day
+    # rollup, but rebuilding it force-refreshes the 25s `week_battles` aggregate
+    # on every ~120s crawl-driven republish — which saturated the 1-vCPU DB on
+    # 2026-05-27 (~20 warms/40min during the ASIA crawl). The recent surfaces
+    # stay fresh via the scheduled beat warmers instead.
+    # See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
     if cache.get(_landing_page_warm_lock_key(realm)):
         return {"status": "skipped", "reason": "already-running"}
 
@@ -264,7 +272,7 @@ def queue_landing_page_warm(realm: str = DEFAULT_REALM):
         return {"status": "skipped", "reason": "already-queued"}
 
     try:
-        warm_landing_page_content_task.delay(include_recent=True, realm=realm)
+        warm_landing_page_content_task.delay(include_recent=include_recent, realm=realm)
         return {"status": "queued"}
     except Exception as error:
         cache.delete(dispatch_key)

--- a/server/warships/tests/test_landing.py
+++ b/server/warships/tests/test_landing.py
@@ -119,7 +119,11 @@ class LandingHelperTests(TestCase):
             cache.get(realm_cache_key('na', LANDING_CLANS_DIRTY_KEY)))
         self.assertIsNotNone(cache.get(realm_cache_key(
             'na', LANDING_RECENT_CLANS_DIRTY_KEY)))
-        mock_delay.assert_called_once_with(include_recent=True, realm='na')
+        # Invalidation-driven republish skips the recent surfaces — they are
+        # owned by their dedicated beat warmers, and rebuilding the recent-
+        # players 7-day rollup on every crawl-driven republish was the
+        # 2026-05-27 DB-CPU saturation.
+        mock_delay.assert_called_once_with(include_recent=False, realm='na')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_marks_dirty_and_preserves_recent_key(self, mock_delay):
@@ -144,7 +148,8 @@ class LandingHelperTests(TestCase):
             cache.get(realm_cache_key('na', LANDING_RECENT_PLAYERS_CACHE_KEY)), ['recent'])
         self.assertIsNotNone(
             cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))
-        mock_delay.assert_called_once_with(include_recent=True, realm='na')
+        # Republish dispatch omits recent surfaces (owned by dedicated warmers).
+        mock_delay.assert_called_once_with(include_recent=False, realm='na')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_preserves_recent_key_by_default(self, mock_delay):
@@ -161,7 +166,8 @@ class LandingHelperTests(TestCase):
             cache.get(realm_cache_key('na', LANDING_RECENT_PLAYERS_CACHE_KEY)), ['recent'])
         self.assertIsNotNone(
             cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))
-        mock_delay.assert_called_once_with(include_recent=True, realm='na')
+        # Republish dispatch omits recent surfaces (owned by dedicated warmers).
+        mock_delay.assert_called_once_with(include_recent=False, realm='na')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_preserves_namespace_by_default(self, mock_delay):
@@ -181,7 +187,8 @@ class LandingHelperTests(TestCase):
         self.assertEqual(original_published_key, rebuilt_published_key)
         self.assertIsNotNone(
             cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))
-        mock_delay.assert_called_once_with(include_recent=True, realm='na')
+        # Republish dispatch omits recent surfaces (owned by dedicated warmers).
+        mock_delay.assert_called_once_with(include_recent=False, realm='na')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_bumps_namespace_when_requested(self, mock_delay):
@@ -652,6 +659,20 @@ class LandingHelperTests(TestCase):
             landing_mod._queue_landing_republish(realm='eu')
             self.assertEqual(mock_warm.call_count, 2)
 
+    def test_queue_landing_republish_excludes_recent_surfaces(self):
+        # Invalidation-driven republishes (clan/player writes) must NOT rebuild
+        # the recent surfaces: clan/player writes don't change the recent-players
+        # 7-day rollup, and force-refreshing its 25s `week_battles` aggregate on
+        # every ~120s crawl-driven republish saturated the 1-vCPU DB on
+        # 2026-05-27. The recent surfaces stay fresh via their dedicated beat
+        # warmers. The scheduled 55-min warmer dispatches the task directly
+        # (include_recent=True) and is unaffected.
+        # See runbook-db-cpu-saturation-2026-05-24.md.
+        from warships import landing as landing_mod
+        with patch('warships.tasks.queue_landing_page_warm') as mock_warm:
+            landing_mod._queue_landing_republish(realm='na')
+            mock_warm.assert_called_once_with(realm='na', include_recent=False)
+
     def test_best_clan_wr_sort_ignores_tiny_cb_samples(self):
         now = timezone.now()
 
@@ -992,7 +1013,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(payload, [{'name': 'published-clan'}])
         self.assertEqual(metadata['ttl_seconds'], LANDING_CLAN_CACHE_TTL)
         mock_builder.assert_not_called()
-        mock_queue_warm.assert_called_once_with(realm='na')
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
 
     @patch('warships.tasks.queue_landing_page_warm', return_value={'status': 'queued'})
     def test_landing_players_use_published_fallback_when_primary_cache_is_missing(self, mock_queue_warm):
@@ -1012,7 +1033,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(payload, [{'name': 'published-player'}])
         self.assertEqual(metadata['ttl_seconds'], LANDING_PLAYER_CACHE_TTL)
         mock_builder.assert_not_called()
-        mock_queue_warm.assert_called_once_with(realm='na')
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
 
     def test_landing_clan_primary_cache_hit_backfills_published_fallback(self):
         cache.set(realm_cache_key('na', LANDING_CLANS_CACHE_KEY),
@@ -1075,7 +1096,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(payload, [{'name': 'published-best-clan'}])
         self.assertEqual(metadata['ttl_seconds'], LANDING_CLAN_CACHE_TTL)
         mock_builder.assert_not_called()
-        mock_queue_warm.assert_called_once_with(realm='na')
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
 
     @patch('warships.tasks.queue_landing_page_warm', return_value={'status': 'queued'})
     def test_best_landing_clans_preserve_non_empty_published_payload_when_primary_is_empty(self, mock_queue_warm):
@@ -1105,7 +1126,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(metadata['ttl_seconds'], LANDING_CLAN_CACHE_TTL)
         self.assertEqual(cache.get(published_cache_key),
                          [{'name': 'durable-best-clan'}])
-        mock_queue_warm.assert_called_once_with(realm='na')
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
 
     def test_warm_landing_page_content_force_refresh_republishes_recent_surfaces_without_deleting(self):
         cache.set(realm_cache_key('na', LANDING_RECENT_CLANS_CACHE_KEY), [


### PR DESCRIPTION
## Incident
DO alert "CPU is running high" on the managed Postgres (`db-postgresql-nyc3-11231`, **1 vCPU**) on 2026-05-27, ~23:00 UTC. Re-diagnosed live from the DO Prometheus metrics endpoint: instantaneous CPU ~22% but **`load15=4.38` on a single core** — genuine saturation, receding. `pg_stat_activity` showed **0 active client backends** across 6 samples → bursty periodic work, not one long query.

## Root cause
The multi-day ASIA `crawl_all_clans_task` continuously re-dirties the landing clan cache. The `LANDING_REPUBLISH_COOLDOWN_SECONDS=120` floor let `warm_landing_page_content_task` fire **~every 2 min (20×/40min, 13–83s each)**. Each republish ran `include_recent=True`, **force-rebuilding the recent-_players_ 7-day rollup (the 25s `week_battles` `PlayerDailyShipStats` SUM)** even though only clan data changed. ~20 rebuilds/40min on one core ≈ the load-4.4 saturation; the 23:00 ASIA periodic cluster (observation floor, ranked) stacked on top tipped it >90%.

This is **fix-directions #2/#3** from `runbook-db-cpu-saturation-2026-05-24.md`, never shipped in the 2026-05-25 remediation (only #1, the `score_best_clans` cache, landed — and it held: that fingerprint dropped 12,443→1,707 calls).

The loud `enrich_player_data_task` fan-out during crawls (~1,190/hr) is the known defer-before-lock churn — **Redis-only, ~3ms/call, NOT the CPU driver.** Separate PR.

## Fix
- `queue_landing_page_warm(realm, include_recent=True)` parameterized; `_queue_landing_republish` now passes **`include_recent=False`**. Recent surfaces stay fresh via their dedicated beat warmers; the 55-min landing warmer dispatches the task directly with `include_recent=True` (unaffected).
- `LANDING_REPUBLISH_COOLDOWN_SECONDS` default **120 → 600** (+ durable in `server/.env.cloud`) — caps crawl-driven republishes at ~6/hr.

## Tests
4 invalidation/fallback dispatch assertions updated to `include_recent=False`; new `test_queue_landing_republish_excludes_recent_surfaces`. **Backend release gate (251 tests) green.**

## Follow-ups
- Republish still force-refreshes `players_best_*`/`players_popular` (cheap vs `week_battles`); a clan-surfaces-only republish is the deeper slice if CPU stays elevated.
- Resize 1→2 vCPU deferred: ship this, watch a full crawl cycle, revisit (209 CPU episodes/24 days).
- Enrichment defer-before-lock fan-out: separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)