### PR TITLE
DB-CPU follow-ups: startup warm + scoped republish + enrich fan-out fix

### DIFF
--- a/agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md
+++ b/agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md
@@ -272,7 +272,8 @@ A fresh "CPU 90%+ since ~23:00 UTC" report. Re-diagnosed from the cluster direct
 2. `LANDING_REPUBLISH_COOLDOWN_SECONDS` default **120 → 600** (and set durably in `server/.env.cloud`) — caps crawl-driven republishes at ~6/hr.
 3. Tests: 4 invalidation/fallback dispatch assertions updated to `include_recent=False`; new `test_queue_landing_republish_excludes_recent_surfaces`. Full backend release gate (251 tests) green.
 
-**Still open / follow-ups:**
-- The republish warm still force-refreshes `players_best_*` + `players_popular` (cheaper than `week_battles`, but a clan write shouldn't touch player surfaces at all). A "clan-surfaces-only" republish is the deeper slice if CPU is still elevated after this lands.
-- **Resize question** (1→2 vCPU) deferred per user: ship this fix, watch a full ASIA crawl cycle, then revisit. 209 CPU episodes/24 days says 1 vCPU is near its ceiling regardless.
-- Enrichment defer-before-lock fan-out: separate PR.
+**Follow-ups — addressed 2026-05-28 (v1.13.3, one branch / three commits):**
+- ✅ **Item 1 — post-deploy cold-cache spike.** After a worker restart the 3h `score_best_clans` cache goes cold and multiple `(realm,sort)` keys recompute *concurrently* (single-flight is per-key), spiking the 1-vCPU DB to load ~8 (seen right after the v1.13.2 deploy). Fix: force `WARM_CACHES_ON_STARTUP=1` in the deploy/bootstrap scripts (`set_env_value`, since `migrate_env_value` preserved the on-host `0`) so the background worker pre-warms those rankings *sequentially* before request traffic. Safe now: droplet is 7.8 GB + 2 GB swap (the 2026-03-30 OOM was at 3.8 GB) and the warm is Celery-dispatched since v1.2.14.
+- ✅ **Item 2b — clan/player-scoped republish.** `warm_landing_page_content(scope=…)` now narrows both the rebuilt surfaces and the dirty keys it clears; clan writes warm only clan surfaces (no more wasteful `players_best_*`/`players_popular` rebuild), player writes only player surfaces. Periodic/startup warmers keep `scope='all'`.
+- ✅ **Item 3 — enrich defer-before-lock fan-out.** Lock acquired before the crawl check; deferrals no longer re-enqueue (the 15-min Beat kickstart is the retry), so the ~1,190/hr chain churn can't accumulate. Defer path never runs the heavy `_maybe_redispatch_enrichment` candidate scan.
+- ⏳ **Item 2a — resize 1→2 vCPU: deferred per user (2026-05-28).** Watch a full ASIA crawl cycle with the above load-reduction fixes in place; resize only if CPU episodes persist. 209 CPU episodes/24 days says 1 vCPU is near its ceiling regardless, so this stays on the radar.

--- a/server/deploy/bootstrap_droplet.sh
+++ b/server/deploy/bootstrap_droplet.sh
@@ -190,7 +190,9 @@ DJANGO_LOGLEVEL=INFO
 REDIS_URL=redis://127.0.0.1:6379/0
 CELERY_RESULT_BACKEND=rpc://
 ENABLE_CRAWLER_SCHEDULES=1
-WARM_CACHES_ON_STARTUP=0
+# Startup cache warming ON: avoids the request-driven cold-cache recompute
+# stampede on the 1-vCPU DB after a restart. See runbook-db-cpu-saturation-2026-05-24.md.
+WARM_CACHES_ON_STARTUP=1
 CACHE_WARMUP_START_DELAY_SECONDS=5
 HOT_ENTITY_PINNED_PLAYER_NAMES=lil_boots
 BEST_CLAN_EXCLUDED_IDS=1000068602
@@ -220,7 +222,7 @@ fi
 chgrp "${APP_USER}" /etc/battlestats-server.secrets.env
 chmod 640 /etc/battlestats-server.secrets.env
 
-migrate_env_value WARM_CACHES_ON_STARTUP WARM_LANDING_PAGE_ON_STARTUP 0
+migrate_env_value WARM_CACHES_ON_STARTUP WARM_LANDING_PAGE_ON_STARTUP 1
 migrate_env_value CACHE_WARMUP_START_DELAY_SECONDS LANDING_WARMUP_START_DELAY_SECONDS 5
 
 cat > /etc/systemd/system/battlestats-gunicorn.service <<EOF

--- a/server/deploy/deploy_to_droplet.sh
+++ b/server/deploy/deploy_to_droplet.sh
@@ -405,7 +405,16 @@ materialize_best_player_snapshots() {
   "${APP_ROOT}/venv/bin/python" manage.py materialize_landing_player_best_snapshots "${args[@]}"
 }
 
-migrate_env_value WARM_CACHES_ON_STARTUP WARM_LANDING_PAGE_ON_STARTUP 0
+# Startup cache warming forced ON (2026-05-28): pre-warms score_best_clans +
+# landing sequentially on the background worker after deploy, replacing the
+# request-driven CONCURRENT cold-cache recompute that spiked the 1-vCPU DB to
+# load ~8 immediately post-deploy. set_env_value (not migrate_*) so every
+# deploy enforces it regardless of the prior on-host value (which was 0).
+# Droplet headroom is ample (7.8 GB + 2 GB swap; the 2026-03-30 OOM was at
+# 3.8 GB) and the warm is Celery-dispatched, not a subprocess (v1.2.14).
+# See runbook-db-cpu-saturation-2026-05-24.md.
+set_env_value WARM_CACHES_ON_STARTUP 1
+sed -i '/^WARM_LANDING_PAGE_ON_STARTUP=.*/d' /etc/battlestats-server.env 2>/dev/null || true
 migrate_env_value CACHE_WARMUP_START_DELAY_SECONDS LANDING_WARMUP_START_DELAY_SECONDS 5
 
 set_env_value CELERY_DEFAULT_CONCURRENCY 3

--- a/server/warships/landing.py
+++ b/server/warships/landing.py
@@ -595,7 +595,7 @@ def _clear_cache_family_dirty(*dirty_keys: str) -> None:
         cache.delete_many(list(dirty_keys))
 
 
-def _queue_landing_republish(realm: str = DEFAULT_REALM) -> None:
+def _queue_landing_republish(realm: str = DEFAULT_REALM, scope: str = 'all') -> None:
     from warships.tasks import queue_landing_page_warm
 
     # Debounce: coalesce bursts of invalidations into at most one warm per
@@ -616,7 +616,10 @@ def _queue_landing_republish(realm: str = DEFAULT_REALM) -> None:
     # 2026-05-27 DB-CPU saturation. The recent surfaces are kept fresh by their
     # dedicated beat warmers (recent-players-warmer / the 55-min landing warmer
     # which dispatches the task directly with include_recent=True).
-    queue_landing_page_warm(realm=realm, include_recent=False)
+    # `scope` narrows the warm to the family that was invalidated (clan write ->
+    # 'clans', player write -> 'players') so a clan write doesn't rebuild the
+    # player surfaces and vice versa.
+    queue_landing_page_warm(realm=realm, include_recent=False, scope=scope)
 
 
 def _publish_landing_payload(
@@ -650,6 +653,7 @@ def _get_cached_landing_payload_with_fallback(
     use_published_fallback_when_dirty: bool = False,
     prefer_published_non_empty_payload: bool = False,
     publish_empty_primary_payload: bool = True,
+    republish_scope: str = 'all',
 ) -> tuple[list[dict] | None, dict[str, str | int]]:
     is_dirty = (not force_refresh) and any(
         cache.get(dirty_key) is not None for dirty_key in dirty_keys
@@ -666,7 +670,7 @@ def _get_cached_landing_payload_with_fallback(
                     cache.get(published_metadata_key), ttl_seconds)
                 cache.set(published_metadata_key,
                           published_metadata, timeout=None)
-                _queue_landing_republish(realm=realm)
+                _queue_landing_republish(realm=realm, scope=republish_scope)
                 return published_payload, published_metadata
         if cache.get(metadata_key) is None:
             cache.set(metadata_key, metadata, ttl_seconds)
@@ -681,7 +685,7 @@ def _get_cached_landing_payload_with_fallback(
         published_metadata = _normalize_landing_player_cache_metadata(
             cache.get(published_metadata_key), ttl_seconds)
         cache.set(published_metadata_key, published_metadata, timeout=None)
-        _queue_landing_republish(realm=realm)
+        _queue_landing_republish(realm=realm, scope=republish_scope)
         return published_payload, published_metadata
 
     return None, metadata
@@ -709,6 +713,7 @@ def get_landing_clans_payload_with_cache_metadata(force_refresh: bool = False, r
         force_refresh,
         realm=realm,
         dirty_keys=(realm_cache_key(realm, LANDING_CLANS_DIRTY_KEY),),
+        republish_scope='clans',
     )
 
     if payload is None:
@@ -801,7 +806,7 @@ def invalidate_landing_clan_caches(realm: str = DEFAULT_REALM, queue_republish: 
         realm_cache_key(realm, LANDING_RECENT_CLANS_DIRTY_KEY),
     )
     if queue_republish:
-        _queue_landing_republish(realm=realm)
+        _queue_landing_republish(realm=realm, scope='clans')
 
 
 def invalidate_landing_player_caches(include_recent: bool = False, realm: str = DEFAULT_REALM, queue_republish: bool = True, bump_namespace: bool = False) -> None:
@@ -818,7 +823,7 @@ def invalidate_landing_player_caches(include_recent: bool = False, realm: str = 
     # compatibility but no dirty key needs flipping.
     _mark_cache_family_dirty(*dirty_keys)
     if queue_republish:
-        _queue_landing_republish(realm=realm)
+        _queue_landing_republish(realm=realm, scope='players')
 
 
 def _normalize_cached_id_list(raw_value) -> list[int]:
@@ -897,6 +902,7 @@ def get_landing_best_clans_payload_with_cache_metadata(force_refresh: bool = Fal
         use_published_fallback_when_dirty=True,
         prefer_published_non_empty_payload=True,
         publish_empty_primary_payload=False,
+        republish_scope='clans',
     )
 
     if payload is None:
@@ -1675,6 +1681,7 @@ def get_landing_players_payload_with_cache_metadata(mode: str = 'best', limit: i
         force_refresh,
         realm=realm,
         dirty_keys=(realm_cache_key(realm, LANDING_PLAYERS_DIRTY_KEY),),
+        republish_scope='players',
     )
 
     if payload is None:
@@ -1917,7 +1924,21 @@ def get_landing_recent_players_payload(force_refresh: bool = False, realm: str =
     return list(materialize_landing_recent_players_snapshot(realm=realm)['payload'])
 
 
-def warm_landing_page_content(force_refresh: bool = False, include_recent: bool = True, realm: str = DEFAULT_REALM) -> dict:
+# Surface-scope sets for warm_landing_page_content(scope=...). Invalidation-
+# driven republishes pass the family that actually changed so a clan write does
+# not rebuild player surfaces (and vice versa). The periodic/startup warmers use
+# scope='all'. recent_clans/recent_players are intentionally members of their
+# family set; whether they actually rebuild is still gated by include_recent.
+LANDING_CLAN_WARM_SURFACES = frozenset({
+    'clans_best_overall', 'clans_best_wr', 'recent_clans',
+})
+LANDING_PLAYER_WARM_SURFACES = frozenset({
+    'players_best_overall', 'players_best_ranked', 'players_best_efficiency',
+    'players_best_wr', 'players_best_cb', 'players_popular', 'recent_players',
+})
+
+
+def warm_landing_page_content(force_refresh: bool = False, include_recent: bool = True, realm: str = DEFAULT_REALM, scope: str = 'all') -> dict:
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     # 'players_random' + 'clans' (the random-clan cache) were retired
@@ -1936,6 +1957,13 @@ def warm_landing_page_content(force_refresh: bool = False, include_recent: bool 
         'recent_clans': lambda: len(get_landing_recent_clans_payload(force_refresh=force_refresh if include_recent else False, realm=realm)),
         'recent_players': lambda: len(get_landing_recent_players_payload(force_refresh=force_refresh if include_recent else False, realm=realm)),
     }
+
+    # Narrow to the requested family. Unknown scope falls back to 'all' so a
+    # bad caller never silently warms nothing.
+    if scope == 'clans':
+        surfaces = {k: v for k, v in surfaces.items() if k in LANDING_CLAN_WARM_SURFACES}
+    elif scope == 'players':
+        surfaces = {k: v for k, v in surfaces.items() if k in LANDING_PLAYER_WARM_SURFACES}
 
     def _run_surface(fn):
         from django.db import close_old_connections
@@ -1966,9 +1994,17 @@ def warm_landing_page_content(force_refresh: bool = False, include_recent: bool 
         for name, fn in surfaces.items():
             warmed[name] = fn()
 
-    _clear_cache_family_dirty(
-        realm_cache_key(realm, LANDING_CLANS_DIRTY_KEY),
-        realm_cache_key(realm, LANDING_PLAYERS_DIRTY_KEY),
-        realm_cache_key(realm, LANDING_RECENT_CLANS_DIRTY_KEY),
-    )
+    # Clear only the dirty keys for the family we actually rebuilt. A clan-scoped
+    # warm must NOT clear the players dirty key (it didn't rebuild player
+    # surfaces) — doing so would strand a stale published player payload with no
+    # pending republish until the next periodic warm.
+    dirty_keys = []
+    if scope in ('all', 'clans'):
+        dirty_keys += [
+            realm_cache_key(realm, LANDING_CLANS_DIRTY_KEY),
+            realm_cache_key(realm, LANDING_RECENT_CLANS_DIRTY_KEY),
+        ]
+    if scope in ('all', 'players'):
+        dirty_keys.append(realm_cache_key(realm, LANDING_PLAYERS_DIRTY_KEY))
+    _clear_cache_family_dirty(*dirty_keys)
     return {'status': 'completed', 'warmed': warmed}

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -246,7 +246,7 @@ def is_clan_battle_summary_refresh_pending(clan_id: object, realm: str = DEFAULT
     return bool(cache.get(_clan_battle_summary_refresh_dispatch_key(clan_id, realm=realm)))
 
 
-def queue_landing_page_warm(realm: str = DEFAULT_REALM, include_recent: bool = True):
+def queue_landing_page_warm(realm: str = DEFAULT_REALM, include_recent: bool = True, scope: str = 'all'):
     # If a warm is already executing for this realm, skip enqueue. The 30s
     # dispatch dedup expires while the 1200s task runs, so without this gate,
     # cache-fallback paths invoked from inside the warm itself would re-enqueue
@@ -272,7 +272,7 @@ def queue_landing_page_warm(realm: str = DEFAULT_REALM, include_recent: bool = T
         return {"status": "skipped", "reason": "already-queued"}
 
     try:
-        warm_landing_page_content_task.delay(include_recent=include_recent, realm=realm)
+        warm_landing_page_content_task.delay(include_recent=include_recent, realm=realm, scope=scope)
         return {"status": "queued"}
     except Exception as error:
         cache.delete(dispatch_key)
@@ -869,13 +869,14 @@ def warm_clan_battle_summaries_task(self, clan_ids=None, realm=DEFAULT_REALM):
 
 
 @app.task(bind=True, **TASK_OPTS)
-def warm_landing_page_content_task(self, include_recent=True, realm=DEFAULT_REALM):
+def warm_landing_page_content_task(self, include_recent=True, realm=DEFAULT_REALM, scope='all'):
     from warships.landing import warm_landing_page_content
 
     logger.info(
-        "Starting warm_landing_page_content_task include_recent=%s realm=%s",
+        "Starting warm_landing_page_content_task include_recent=%s realm=%s scope=%s",
         include_recent,
         realm,
+        scope,
     )
 
     lock_key = _landing_page_warm_lock_key(realm)
@@ -890,6 +891,7 @@ def warm_landing_page_content_task(self, include_recent=True, realm=DEFAULT_REAL
             force_refresh=True,
             include_recent=bool(include_recent),
             realm=realm,
+            scope=scope,
         )
         logger.info("Finished warm_landing_page_content_task: %s", result)
         return result

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -1411,26 +1411,36 @@ def enrich_player_data_task(self):
     limits.  Runs on the dedicated background worker so it never competes
     with user-facing tasks on the default/hydration queues.
     """
-    # Defer if any clan crawl is running — they share the WG API rate limit.
+    # Acquire the single-flight lock FIRST. Duplicate dispatches (the 15-min
+    # Beat kickstart, acks_late redelivery, and the startup-warmer kickstart can
+    # coincide) return here without re-enqueuing — so deferrals can't fan out
+    # into accumulating 300s-recurring chains (the 2026-05-27 ~1,190/hr churn
+    # while a clan crawl was active). See runbook-db-cpu-saturation-2026-05-24.md.
+    lock_key = _enrich_player_data_lock_key()
+    if not cache.add(lock_key, self.request.id, timeout=ENRICH_PLAYER_DATA_LOCK_TIMEOUT):
+        logger.info(
+            "Skipping enrich_player_data_task — another enrichment is already running")
+        return {"status": "skipped", "reason": "already-running"}
+
+    # Defer while a clan crawl is active (shared WG API rate limit). We hold the
+    # lock, so release it and return WITHOUT re-enqueuing: the every-15-min Beat
+    # kickstart (player-enrichment-kickstart) is the retry, bounding deferrals to
+    # one no-op per cycle instead of a self-multiplying chain. (Benign race: a
+    # crawl may start between this check and enrich_players below; that batch
+    # competes for the WG budget once and the next dispatch defers. The 6h lock
+    # TTL + heartbeat lets a long-running batch hold the lock safely.)
     from warships.models import VALID_REALMS as _realms
     active_crawls = [
         r for r in sorted(_realms)
         if cache.get(_clan_crawl_lock_key(r)) is not None
     ]
     if active_crawls:
-        retry_delay = 300  # check again in 5 minutes
+        cache.delete(lock_key)
         logger.info(
-            "Deferring enrichment — clan crawl active for %s, retrying in %ds",
-            active_crawls, retry_delay,
+            "Deferring enrichment — clan crawl active for %s; Beat kickstart will retry",
+            active_crawls,
         )
-        enrich_player_data_task.apply_async(countdown=retry_delay)
         return {"status": "deferred", "reason": "crawl-running", "active_crawls": active_crawls}
-
-    lock_key = _enrich_player_data_lock_key()
-    if not cache.add(lock_key, self.request.id, timeout=ENRICH_PLAYER_DATA_LOCK_TIMEOUT):
-        logger.info(
-            "Skipping enrich_player_data_task — another enrichment is already running")
-        return {"status": "skipped", "reason": "already-running"}
 
     try:
         from warships.management.commands.enrich_player_data import enrich_players

--- a/server/warships/tests/test_enrichment_task.py
+++ b/server/warships/tests/test_enrichment_task.py
@@ -1,0 +1,78 @@
+"""Unit coverage for enrich_player_data_task's lock/defer control flow.
+
+Regression guard for the 2026-05-27 deferral fan-out: while a clan crawl is
+active the task must NOT re-enqueue itself (the every-15-min Beat kickstart is
+the retry), and the lock must be acquired BEFORE the crawl check so duplicate
+dispatches dedup instead of each spawning a self-recurring chain. The defer
+path must also never run the heavy `_maybe_redispatch_enrichment` candidate
+scan. See agents/runbooks/runbook-db-cpu-saturation-2026-05-24.md.
+"""
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from warships.tasks import (
+    ENRICH_PLAYER_DATA_LOCK_TIMEOUT,
+    _clan_crawl_lock_key,
+    _enrich_player_data_lock_key,
+    enrich_player_data_task,
+)
+
+
+class EnrichPlayerDataTaskControlFlowTests(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_defer_when_crawl_active_releases_lock_and_does_not_reenqueue(self):
+        cache.set(_clan_crawl_lock_key('na'), '1', 300)
+
+        with patch('warships.management.commands.enrich_player_data.enrich_players') as mock_enrich, \
+                patch('warships.tasks._maybe_redispatch_enrichment') as mock_redispatch, \
+                patch('warships.tasks.enrich_player_data_task.apply_async') as mock_apply_async:
+            result = enrich_player_data_task.apply().get()
+
+        self.assertEqual(result['status'], 'deferred')
+        self.assertEqual(result['reason'], 'crawl-running')
+        self.assertIn('na', result['active_crawls'])
+        # No fan-out: deferral must not re-enqueue itself…
+        mock_apply_async.assert_not_called()
+        # …and must not run the heavy candidate scan…
+        mock_redispatch.assert_not_called()
+        # …nor touch the WG API.
+        mock_enrich.assert_not_called()
+        # Lock released so the next kickstart can acquire it cleanly.
+        self.assertIsNone(cache.get(_enrich_player_data_lock_key()))
+
+    def test_skips_when_lock_already_held(self):
+        # Another enrichment (or a near-simultaneous duplicate dispatch) holds
+        # the lock — even with no crawl active, we bail without doing work.
+        cache.add(_enrich_player_data_lock_key(), 'other-task-id',
+                  ENRICH_PLAYER_DATA_LOCK_TIMEOUT)
+
+        with patch('warships.management.commands.enrich_player_data.enrich_players') as mock_enrich, \
+                patch('warships.tasks._maybe_redispatch_enrichment') as mock_redispatch, \
+                patch('warships.tasks.enrich_player_data_task.apply_async') as mock_apply_async:
+            result = enrich_player_data_task.apply().get()
+
+        self.assertEqual(result['status'], 'skipped')
+        self.assertEqual(result['reason'], 'already-running')
+        mock_enrich.assert_not_called()
+        mock_redispatch.assert_not_called()
+        mock_apply_async.assert_not_called()
+        # We did not own the lock, so we must not have deleted the holder's.
+        self.assertEqual(cache.get(_enrich_player_data_lock_key()), 'other-task-id')
+
+    def test_runs_batch_and_redispatches_when_no_crawl(self):
+        summary = {'enriched': 3, 'remaining': 0}
+
+        with patch('warships.management.commands.enrich_player_data.enrich_players', return_value=summary) as mock_enrich, \
+                patch('warships.tasks._maybe_redispatch_enrichment') as mock_redispatch:
+            result = enrich_player_data_task.apply().get()
+
+        self.assertEqual(result, summary)
+        mock_enrich.assert_called_once()
+        # A real batch DOES redispatch (the self-chain) exactly once.
+        mock_redispatch.assert_called_once()
+        # Lock released after the batch.
+        self.assertIsNone(cache.get(_enrich_player_data_lock_key()))

--- a/server/warships/tests/test_landing.py
+++ b/server/warships/tests/test_landing.py
@@ -123,7 +123,7 @@ class LandingHelperTests(TestCase):
         # owned by their dedicated beat warmers, and rebuilding the recent-
         # players 7-day rollup on every crawl-driven republish was the
         # 2026-05-27 DB-CPU saturation.
-        mock_delay.assert_called_once_with(include_recent=False, realm='na')
+        mock_delay.assert_called_once_with(include_recent=False, realm='na', scope='clans')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_marks_dirty_and_preserves_recent_key(self, mock_delay):
@@ -149,7 +149,7 @@ class LandingHelperTests(TestCase):
         self.assertIsNotNone(
             cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))
         # Republish dispatch omits recent surfaces (owned by dedicated warmers).
-        mock_delay.assert_called_once_with(include_recent=False, realm='na')
+        mock_delay.assert_called_once_with(include_recent=False, realm='na', scope='players')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_preserves_recent_key_by_default(self, mock_delay):
@@ -167,7 +167,7 @@ class LandingHelperTests(TestCase):
         self.assertIsNotNone(
             cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))
         # Republish dispatch omits recent surfaces (owned by dedicated warmers).
-        mock_delay.assert_called_once_with(include_recent=False, realm='na')
+        mock_delay.assert_called_once_with(include_recent=False, realm='na', scope='players')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_preserves_namespace_by_default(self, mock_delay):
@@ -188,7 +188,7 @@ class LandingHelperTests(TestCase):
         self.assertIsNotNone(
             cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))
         # Republish dispatch omits recent surfaces (owned by dedicated warmers).
-        mock_delay.assert_called_once_with(include_recent=False, realm='na')
+        mock_delay.assert_called_once_with(include_recent=False, realm='na', scope='players')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_invalidate_landing_player_caches_bumps_namespace_when_requested(self, mock_delay):
@@ -671,7 +671,7 @@ class LandingHelperTests(TestCase):
         from warships import landing as landing_mod
         with patch('warships.tasks.queue_landing_page_warm') as mock_warm:
             landing_mod._queue_landing_republish(realm='na')
-            mock_warm.assert_called_once_with(realm='na', include_recent=False)
+            mock_warm.assert_called_once_with(realm='na', include_recent=False, scope='all')
 
     def test_best_clan_wr_sort_ignores_tiny_cb_samples(self):
         now = timezone.now()
@@ -1013,7 +1013,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(payload, [{'name': 'published-clan'}])
         self.assertEqual(metadata['ttl_seconds'], LANDING_CLAN_CACHE_TTL)
         mock_builder.assert_not_called()
-        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False, scope='clans')
 
     @patch('warships.tasks.queue_landing_page_warm', return_value={'status': 'queued'})
     def test_landing_players_use_published_fallback_when_primary_cache_is_missing(self, mock_queue_warm):
@@ -1033,7 +1033,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(payload, [{'name': 'published-player'}])
         self.assertEqual(metadata['ttl_seconds'], LANDING_PLAYER_CACHE_TTL)
         mock_builder.assert_not_called()
-        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False, scope='players')
 
     def test_landing_clan_primary_cache_hit_backfills_published_fallback(self):
         cache.set(realm_cache_key('na', LANDING_CLANS_CACHE_KEY),
@@ -1096,7 +1096,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(payload, [{'name': 'published-best-clan'}])
         self.assertEqual(metadata['ttl_seconds'], LANDING_CLAN_CACHE_TTL)
         mock_builder.assert_not_called()
-        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False, scope='clans')
 
     @patch('warships.tasks.queue_landing_page_warm', return_value={'status': 'queued'})
     def test_best_landing_clans_preserve_non_empty_published_payload_when_primary_is_empty(self, mock_queue_warm):
@@ -1126,7 +1126,7 @@ class LandingHelperTests(TestCase):
         self.assertEqual(metadata['ttl_seconds'], LANDING_CLAN_CACHE_TTL)
         self.assertEqual(cache.get(published_cache_key),
                          [{'name': 'durable-best-clan'}])
-        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False)
+        mock_queue_warm.assert_called_once_with(realm='na', include_recent=False, scope='clans')
 
     def test_warm_landing_page_content_force_refresh_republishes_recent_surfaces_without_deleting(self):
         cache.set(realm_cache_key('na', LANDING_RECENT_CLANS_CACHE_KEY), [
@@ -1773,7 +1773,7 @@ class QueueLandingPageWarmGateTests(TestCase):
         result = queue_landing_page_warm(realm='na')
 
         self.assertEqual(result, {'status': 'queued'})
-        mock_delay.assert_called_once_with(include_recent=True, realm='na')
+        mock_delay.assert_called_once_with(include_recent=True, realm='na', scope='all')
 
     @patch('warships.tasks.warm_landing_page_content_task.delay')
     def test_skips_when_warm_lock_is_held(self, mock_delay):
@@ -1873,3 +1873,72 @@ class QueueWarmPlayerCorrelationsGateTests(TestCase):
             result, {'status': 'skipped', 'reason': 'enqueue-failed'})
         self.assertIsNone(cache.get(_correlation_warm_dispatch_key('na')))
         mock_delay.assert_called_once()
+
+
+class LandingWarmScopeTests(TestCase):
+    """warm_landing_page_content(scope=...) narrows BOTH the rebuilt surfaces and
+    the dirty keys it clears, so an invalidation-driven republish rebuilds only
+    the family that changed. A clan write must not rebuild player surfaces (the
+    2026-05-27 recent-players cost) nor clear the players dirty flag (which would
+    strand the player published fallback with no pending republish). See
+    runbook-db-cpu-saturation-2026-05-24.md.
+    """
+
+    def setUp(self):
+        cache.clear()
+
+    def _run_scope(self, scope, include_recent=True):
+        from warships import landing as landing_mod
+        with patch.object(landing_mod, 'get_landing_players_payload', return_value=[]) as players, \
+                patch.object(landing_mod, 'get_landing_best_clans_payload', return_value=[]) as best_clans, \
+                patch.object(landing_mod, 'get_landing_recent_clans_payload', return_value=[]) as recent_clans, \
+                patch.object(landing_mod, 'get_landing_recent_players_payload', return_value=[]) as recent_players:
+            landing_mod.warm_landing_page_content(
+                force_refresh=True, include_recent=include_recent, realm='na', scope=scope)
+        return players, best_clans, recent_clans, recent_players
+
+    def test_scope_clans_runs_only_clan_surfaces(self):
+        players, best_clans, recent_clans, recent_players = self._run_scope('clans')
+        self.assertTrue(best_clans.called)
+        self.assertTrue(recent_clans.called)  # recent_clans IS a clan-scope surface
+        players.assert_not_called()
+        recent_players.assert_not_called()
+
+    def test_scope_players_runs_only_player_surfaces(self):
+        players, best_clans, recent_clans, recent_players = self._run_scope('players')
+        self.assertTrue(players.called)
+        self.assertTrue(recent_players.called)  # recent_players IS a player-scope surface
+        best_clans.assert_not_called()
+        recent_clans.assert_not_called()
+
+    def test_scope_all_runs_every_surface(self):
+        players, best_clans, recent_clans, recent_players = self._run_scope('all')
+        self.assertTrue(players.called)
+        self.assertTrue(best_clans.called)
+        self.assertTrue(recent_clans.called)
+        self.assertTrue(recent_players.called)
+
+    def test_surface_family_sets_partition_correctly(self):
+        # Off-by-one guard: a startswith('clans_') test would miss recent_clans.
+        from warships.landing import LANDING_CLAN_WARM_SURFACES, LANDING_PLAYER_WARM_SURFACES
+        self.assertIn('recent_clans', LANDING_CLAN_WARM_SURFACES)
+        self.assertIn('recent_players', LANDING_PLAYER_WARM_SURFACES)
+        self.assertNotIn('recent_players', LANDING_CLAN_WARM_SURFACES)
+        self.assertNotIn('recent_clans', LANDING_PLAYER_WARM_SURFACES)
+        self.assertEqual(
+            LANDING_CLAN_WARM_SURFACES & LANDING_PLAYER_WARM_SURFACES, frozenset())
+
+    def test_clan_scope_clears_only_clan_dirty_keys(self):
+        from warships import landing as landing_mod
+        cache.set(realm_cache_key('na', LANDING_CLANS_DIRTY_KEY), 'd', timeout=None)
+        cache.set(realm_cache_key('na', LANDING_RECENT_CLANS_DIRTY_KEY), 'd', timeout=None)
+        cache.set(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY), 'd', timeout=None)
+        with patch.object(landing_mod, 'get_landing_players_payload', return_value=[]), \
+                patch.object(landing_mod, 'get_landing_best_clans_payload', return_value=[]), \
+                patch.object(landing_mod, 'get_landing_recent_clans_payload', return_value=[]), \
+                patch.object(landing_mod, 'get_landing_recent_players_payload', return_value=[]):
+            landing_mod.warm_landing_page_content(force_refresh=True, realm='na', scope='clans')
+        self.assertIsNone(cache.get(realm_cache_key('na', LANDING_CLANS_DIRTY_KEY)))
+        self.assertIsNone(cache.get(realm_cache_key('na', LANDING_RECENT_CLANS_DIRTY_KEY)))
+        # Players dirty key must survive — clan scope did not rebuild player surfaces.
+        self.assertIsNotNone(cache.get(realm_cache_key('na', LANDING_PLAYERS_DIRTY_KEY)))


### PR DESCRIPTION
Addresses the 3 follow-ups from the v1.13.2 DB-CPU incident (`runbook-db-cpu-saturation-2026-05-24.md`). Three granular commits so any one is independently revertable.

### Item 1 — post-deploy cold-cache CPU spike  (`perf(deploy)`)
After a worker restart the 3h `score_best_clans` cache goes cold; the first landing requests recompute multiple `(realm,sort)` keys **concurrently** (single-flight is per-key), spiking the 1-vCPU DB to load ~8 (observed right after the v1.13.2 deploy). Force `WARM_CACHES_ON_STARTUP=1` in the deploy/bootstrap scripts (via `set_env_value` — `migrate_env_value` preserved the on-host `0`) so the background worker pre-warms those rankings **sequentially** before traffic. Safe: droplet is 7.8 GB + 2 GB swap (the 2026-03-30 OOM was at 3.8 GB) and the warm is Celery-dispatched since v1.2.14.

### Item 2b — clan/player-scoped republish  (`perf(landing)`)
A clan write still rebuilt `players_best_*` + `players_popular`. `warm_landing_page_content(scope=…)` now narrows both the rebuilt surfaces **and** the dirty keys it clears (clan-scoped warm must not clear the players dirty flag — that would strand the player published fallback). Threaded through `warm_landing_page_content_task → queue_landing_page_warm → _queue_landing_republish → _get_cached_landing_payload_with_fallback`. Periodic/startup warmers keep `scope='all'`.

### Item 3 — enrich defer-before-lock fan-out  (`fix(enrich)`)
Lock acquired **before** the crawl check; deferrals no longer re-enqueue (the 15-min Beat kickstart is the retry), so the ~1,190/hr deferral-chain churn can't accumulate. Defer path returns before the `try/finally`, so it never runs the heavy `_maybe_redispatch_enrichment` candidate scan.

### Item 2a — resize 1→2 vCPU: **deferred** (your call)
Watch a full ASIA crawl cycle with these fixes first; resize only if episodes persist.

### Tests
- New `test_enrichment_task.py` (3): defer releases lock + no re-enqueue + no redispatch; lock-held → skipped; no-crawl → batch + redispatch once.
- New `LandingWarmScopeTests` (5): clan/player/all surface sets, family-set partition guard (`recent_clans`/`recent_players`), clan scope clears only clan dirty keys.
- 8 existing dispatch assertions updated with the `scope` kwarg.
- **Backend release gate: 259 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)