### PR TITLE
feat(player): auto-refresh in place when the live-update cooldown hits zero

### DIFF
--- a/client/app/components/__tests__/usePlayerLiveRefresh.test.ts
+++ b/client/app/components/__tests__/usePlayerLiveRefresh.test.ts
@@ -1,8 +1,14 @@
+import { renderHook, act } from '@testing-library/react';
 import {
     computeSecondsRemaining,
     parseNextRefreshHeader,
     parsePendingHeader,
+    usePlayerLiveRefresh,
 } from '../usePlayerLiveRefresh';
+import { fetchSharedJson } from '../../lib/sharedJsonFetch';
+
+jest.mock('../../lib/sharedJsonFetch', () => ({ fetchSharedJson: jest.fn() }));
+const mockFetch = fetchSharedJson as jest.MockedFunction<typeof fetchSharedJson>;
 
 describe('usePlayerLiveRefresh helpers', () => {
     it('parses the refresh-pending header', () => {
@@ -28,5 +34,56 @@ describe('usePlayerLiveRefresh helpers', () => {
         // Past target / missing anchor → no negative countdown.
         expect(computeSecondsRemaining(nowEpoch - 100)).toBe(0);
         expect(computeSecondsRemaining(null)).toBe(0);
+    });
+});
+
+describe('usePlayerLiveRefresh auto-refresh on cooldown expiry', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockFetch.mockReset();
+        // Poll target for the auto-fired refresh (never reached in the
+        // anchor-less test, harmless there).
+        mockFetch.mockResolvedValue({ data: { player_id: 1 } as never, headers: {} });
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('auto-triggers an in-place refresh (phase → loading) when the cooldown reaches zero', () => {
+        const nowEpoch = Math.floor(Date.now() / 1000);
+        const { result, unmount } = renderHook(() => usePlayerLiveRefresh({
+            playerName: 'lil_boots',
+            realm: 'na',
+            initialPending: false,
+            initialNextRefresh: nowEpoch + 2, // cooldown expires in ~2s
+            onRehydrate: jest.fn(),
+        }));
+
+        expect(result.current.phase).toBe('cooldown');
+        expect(result.current.secondsRemaining).toBeGreaterThan(0);
+
+        // Cross the cooldown boundary → the hook re-enters the loading poll
+        // in place (no reload); phase flips to loading.
+        act(() => { jest.advanceTimersByTime(3000); });
+        expect(result.current.phase).toBe('loading');
+
+        unmount();
+    });
+
+    it('does NOT auto-fire when there is no cooldown anchor (avoids spurious refresh)', () => {
+        const { result, unmount } = renderHook(() => usePlayerLiveRefresh({
+            playerName: 'lil_boots',
+            realm: 'na',
+            initialPending: false,
+            initialNextRefresh: null, // no anchor → secondsRemaining is 0 from the start
+            onRehydrate: jest.fn(),
+        }));
+
+        expect(result.current.phase).toBe('cooldown');
+        act(() => { jest.advanceTimersByTime(5000); });
+        // Stays in cooldown — never auto-kicks a refresh without a real target.
+        expect(result.current.phase).toBe('cooldown');
+
+        unmount();
     });
 });

--- a/client/app/components/usePlayerLiveRefresh.ts
+++ b/client/app/components/usePlayerLiveRefresh.ts
@@ -52,8 +52,10 @@ interface UsePlayerLiveRefreshParams {
  *    player endpoint (cache-busted) until X-Player-Refresh-Pending clears,
  *    re-hydrating on each poll, then transition to cooldown.
  *  - phase "cooldown": tick a server-anchored countdown to X-Player-Next-Refresh
- *    (every visitor sees the same target). At 0 a new pull becomes possible on
- *    the next visit — we never auto-fire, matching the server-side lock.
+ *    (every visitor sees the same target). At 0 we auto-trigger an in-place
+ *    refresh (re-enter the loading poll → rehydrate → reset the countdown, no
+ *    page reload). The server-side cooldown lock + visit dedup still gate the
+ *    actual upstream pull, so an open/idle tab can't over-refresh.
  */
 export const usePlayerLiveRefresh = ({
     playerName,
@@ -144,15 +146,39 @@ export const usePlayerLiveRefresh = ({
     }, [pending, playerName, realm]);
 
     // Countdown tick during cooldown (recompute from the absolute target each
-    // tick, so it's correct after tab sleep / throttling).
+    // tick, so it's correct after tab sleep / throttling). When the cooldown
+    // elapses we AUTO-TRIGGER an in-place refresh instead of parking on "Update
+    // available": flipping `pending` re-enters the poll loop above, which
+    // re-fetches the (cache-busted) endpoint — the server dispatches the
+    // visit-driven refresh when stale (views.py) — then rehydrates via
+    // onRehydrate + a single refreshNonce bump and resets the countdown, all
+    // WITHOUT a page reload (SPA-style; reloading is disruptive).
+    //
+    // Fire only on the >0 → 0 down-crossing. The detector re-arms on any tick
+    // where `remaining > 0` (a "fresh" anchor), so:
+    //  - a successful refresh sets a future anchor (~15 min) → arms → fires again
+    //    at the next expiry (continuous in-place updates while the page is open);
+    //  - a refresh that fails to land leaves us parked at 0 (prev stays 0, never
+    //    >0) → does NOT hot-loop re-firing every tick; it waits for a real anchor.
     useEffect(() => {
         if (pending) {
             return;
         }
+        let prevRemaining = secondsRemaining;
         const intervalId = window.setInterval(() => {
-            setSecondsRemaining(computeSecondsRemaining(nextRefresh));
+            const remaining = computeSecondsRemaining(nextRefresh);
+            setSecondsRemaining(remaining);
+            if (nextRefresh !== null && prevRemaining > 0 && remaining <= 0) {
+                setPending(true);
+            }
+            prevRemaining = remaining;
         }, 1_000);
         return () => window.clearInterval(intervalId);
+        // `secondsRemaining` is read ONCE at effect setup to seed the crossing
+        // detector; later values are tracked via the local `prevRemaining`
+        // closure, so omitting it from deps does NOT cause a stale read — and
+        // including it would re-create the interval every tick (churn).
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pending, nextRefresh]);
 
     return {

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "jest --runInBand app/lib/__tests__/entityRoutes.test.ts app/lib/__tests__/visitAnalytics.test.ts app/components/__tests__/PlayerSearch.test.tsx app/components/__tests__/PlayerRouteViewWarmup.test.tsx app/components/__tests__/PlayerDetail.test.tsx app/components/__tests__/PlayerDetailInsightsTabs.test.tsx app/components/__tests__/ClanRouteView.test.tsx app/components/__tests__/ClanDetail.test.tsx app/components/__tests__/RealmSelector.test.tsx app/components/__tests__/HeaderSearch.test.tsx app/components/__tests__/BattleHistoryCard.test.tsx",
+    "test": "jest --runInBand app/lib/__tests__/entityRoutes.test.ts app/lib/__tests__/visitAnalytics.test.ts app/components/__tests__/PlayerSearch.test.tsx app/components/__tests__/PlayerRouteViewWarmup.test.tsx app/components/__tests__/PlayerDetail.test.tsx app/components/__tests__/PlayerDetailInsightsTabs.test.tsx app/components/__tests__/ClanRouteView.test.tsx app/components/__tests__/ClanDetail.test.tsx app/components/__tests__/RealmSelector.test.tsx app/components/__tests__/HeaderSearch.test.tsx app/components/__tests__/BattleHistoryCard.test.tsx app/components/__tests__/usePlayerLiveRefresh.test.ts",
     "test:ci": "npm test"
   },
   "dependencies": {


### PR DESCRIPTION
## What
The player-page live-update countdown parked on **"Update available"** at zero and only refreshed on the next full page visit/reload — disruptive, not SPA-like. Now, when the cooldown reaches zero the page **auto-refreshes in place (no reload)** and the timer resets.

## How
At the cooldown's `>0 → 0` down-crossing the hook re-enters its existing **loading poll**:
1. Re-fetches the (cache-busted) `/api/player/<name>/` endpoint.
2. The server **already** dispatches the visit-driven refresh when stale (`views.py` — gated by a 15-min staleness window + 60s dedup + per-player lock).
3. Polls until `X-Player-Refresh-Pending` clears, then rehydrates **once** via `onRehydrate` + a single `refreshNonce` bump (header summary + charts update) and resets the countdown — **no page reload**.

Fires only on the down-crossing so a refresh that fails to land (parked at 0) can't hot-loop; it re-arms on any tick where `remaining > 0`, giving continuous in-place updates while the page is open. The server-side cooldown lock + visit dedup still cap the actual upstream pull, so open/idle tabs can't over-refresh. (This intentionally reverses the prior "never auto-fire" choice, per the SPA request.)

## Tests
`usePlayerLiveRefresh.test.ts` gains hook-behavior cases (auto-fire → `loading` on cooldown expiry; **no** auto-fire without a real anchor) and is **added to the curated frontend gate** — it was previously not run by `npm test`/CI (pre-existing gap). Frontend gate green: ESLint, 106 jest tests, build.

## Verification note (honest)
Unlike a static UI change, this can't be fully verified on prod by curl/bundle-grep — that only confirms the auto-fire code is *present*, not that the timer *resets* after the in-place refresh. True verification is observational: open a player page, watch the countdown cross zero, see the pill flash "Loading…" and the timer reset to ~15 min with no reload. Tests cover the auto-fire transition; the end-to-end reset rides on the already-shipped loading-poll path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)