### PR TITLE
fix(player): keep battle-history mounted during rehydrate (no blink/reflow)

### DIFF
--- a/client/app/components/BattleHistoryCard.tsx
+++ b/client/app/components/BattleHistoryCard.tsx
@@ -652,7 +652,14 @@ const BattleHistoryCard: React.FC<BattleHistoryCardProps> = ({
         return rows;
     }, [payload?.by_ship, sort]);
 
-    if (loading || error) {
+    // Only bail before the FIRST payload (or on error). On a re-fetch — a
+    // window/mode switch or a live-update `refreshNonce` rehydrate — we keep
+    // rendering the existing `payload` instead of collapsing to null. Returning
+    // null mid-refresh unmounted the whole card, so the live-update rehydrate
+    // made it blink out and back in, shifting the page content. Holding the
+    // prior data lets React reconcile the new rows in place — a smooth swap.
+    // (The header live-refresh pill already signals "Loading…" during the pull.)
+    if (error || !payload) {
         return null;
     }
     const totals = payload?.totals;

--- a/client/app/components/__tests__/BattleHistoryCard.test.tsx
+++ b/client/app/components/__tests__/BattleHistoryCard.test.tsx
@@ -150,6 +150,27 @@ describe('BattleHistoryCard', () => {
         expect(rows[2].textContent).toContain('Dalian');
     });
 
+    test('stays mounted with prior data during a refreshNonce rehydrate (no blink/reflow)', async () => {
+        resolveWith(buildPayload());
+        const { rerender } = render(
+            <BattleHistoryCard playerName="lil_boots" realm="na" refreshNonce={0} />,
+        );
+        await waitFor(() => {
+            expect(screen.getByTestId('battle-history-card')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Yamato')).toBeInTheDocument();
+
+        // The live-update rehydrate bumps refreshNonce → a re-fetch starts. Keep
+        // that fetch in flight (never resolves) to hold the component in its
+        // loading state, then assert the card did NOT unmount — the old data
+        // stays on screen so there's no disappear/reappear blink or layout shift.
+        mockFetchSharedJson.mockReturnValueOnce(new Promise<never>(() => {}));
+        rerender(<BattleHistoryCard playerName="lil_boots" realm="na" refreshNonce={1} />);
+
+        expect(screen.getByTestId('battle-history-card')).toBeInTheDocument();
+        expect(screen.getByText('Yamato')).toBeInTheDocument();
+    });
+
     test('renders nothing while loading', () => {
         // Never resolve.
         mockFetchSharedJson.mockReturnValueOnce(new Promise(() => {}));


### PR DESCRIPTION
## Problem
On a live-update rehydrate (the `refreshNonce` bump from `usePlayerLiveRefresh`), the battle-history card **blinked out and back in**, shifting the surrounding page content.

## Cause
The fetch effect calls `setLoading(true)` on every re-fetch, and the render guard `if (loading || error) return null` unmounted the **whole card** during the in-flight refresh → disappear → reappear → layout reflow.

## Fix
Guard on `error || !payload` instead: bail only **before the first payload** (or on error). On any re-fetch (window/mode switch *or* live-update rehydrate) keep rendering the existing `payload`, so React reconciles the new rows **in place** — a smooth swap, no unmount. The header live-refresh pill already shows "Loading…" during the pull, so the refresh is still signalled.

## Test
New case: the card stays mounted with its prior data while a `refreshNonce`-triggered re-fetch is in flight (proves no disappear/reappear). Frontend gate green: ESLint, 107 jest, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)