### PR TITLE
feat(player): live-update pill polish — rainbow Loading + drop "Update available"

### DIFF
--- a/client/app/components/PlayerDetail.tsx
+++ b/client/app/components/PlayerDetail.tsx
@@ -437,17 +437,15 @@ const PlayerDetail: React.FC<PlayerDetailProps> = ({
                                         >
                                             Loading…
                                         </span>
-                                    ) : (
+                                    ) : refreshStatus.secondsRemaining > 0 ? (
                                         <span
                                             className="text-xs font-medium text-[var(--accent-light)]"
                                             aria-live="polite"
                                             data-testid="live-refresh-status"
                                         >
-                                            {refreshStatus.secondsRemaining > 0
-                                                ? `Next update: ${Math.ceil(refreshStatus.secondsRemaining / 60)} min`
-                                                : 'Update available'}
+                                            {`Next update: ${Math.ceil(refreshStatus.secondsRemaining / 60)} min`}
                                         </span>
-                                    )
+                                    ) : null
                                 ) : null}
                                 <button
                                     type="button"

--- a/client/app/components/PlayerDetail.tsx
+++ b/client/app/components/PlayerDetail.tsx
@@ -431,7 +431,7 @@ const PlayerDetail: React.FC<PlayerDetailProps> = ({
                                 {refreshStatus && !player.is_hidden ? (
                                     refreshStatus.phase === 'loading' ? (
                                         <span
-                                            className="animate-pulse text-xs font-medium text-[var(--accent-light)]"
+                                            className="rainbow-text text-xs font-semibold"
                                             aria-live="polite"
                                             data-testid="live-refresh-status"
                                         >

--- a/client/app/components/__tests__/PlayerDetail.test.tsx
+++ b/client/app/components/__tests__/PlayerDetail.test.tsx
@@ -188,7 +188,11 @@ describe('PlayerDetail efficiency-rank icon', () => {
             />,
         );
 
-        expect(screen.getByTestId('live-refresh-status')).toHaveTextContent('Loading');
+        const status = screen.getByTestId('live-refresh-status');
+        expect(status).toHaveTextContent('Loading');
+        // The in-progress "Loading…" pill uses the animated rainbow text so the
+        // refresh is hard to miss; the cooldown/"Update available" text does not.
+        expect(status).toHaveClass('rainbow-text');
     });
 
     it('shows the cooldown countdown in minutes left of the share button', () => {

--- a/client/app/components/__tests__/PlayerDetail.test.tsx
+++ b/client/app/components/__tests__/PlayerDetail.test.tsx
@@ -191,7 +191,7 @@ describe('PlayerDetail efficiency-rank icon', () => {
         const status = screen.getByTestId('live-refresh-status');
         expect(status).toHaveTextContent('Loading');
         // The in-progress "Loading…" pill uses the animated rainbow text so the
-        // refresh is hard to miss; the cooldown/"Update available" text does not.
+        // refresh is hard to miss; the steady-state "Next update" text does not.
         expect(status).toHaveClass('rainbow-text');
     });
 
@@ -207,6 +207,23 @@ describe('PlayerDetail efficiency-rank icon', () => {
         );
 
         expect(screen.getByTestId('live-refresh-status')).toHaveTextContent('Next update: 12 min');
+    });
+
+    it('renders no status pill once the cooldown reaches zero (auto-refresh handles it)', () => {
+        // At zero the hook flips to phase "loading" in the same tick, so a
+        // cooldown/zero render is only the brief parked state — show nothing
+        // rather than a stale "Update available" prompt.
+        render(
+            <PlayerDetail
+                player={basePlayer}
+                onBack={() => undefined}
+                onSelectMember={() => undefined}
+                onSelectClan={() => undefined}
+                refreshStatus={{ phase: 'cooldown', secondsRemaining: 0 }}
+            />,
+        );
+
+        expect(screen.queryByTestId('live-refresh-status')).not.toBeInTheDocument();
     });
 
     it('suppresses the live-refresh badge for hidden players', () => {

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -102,6 +102,34 @@ body {
   }
 }
 
+/* Animated rainbow gradient text — used for the live-update "Loading…" pill so
+   an in-progress refresh is hard to miss. The gradient repeats its first color
+   at the end so the 0% → 200% position sweep loops seamlessly. */
+.rainbow-text {
+  background-image: linear-gradient(
+    90deg,
+    #ff2400, #e81d1d, #e8b71d, #1de840, #1ddde8, #2b1de8, #dd00f3, #ff2400
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: rainbow-text-flow 2s linear infinite;
+}
+
+@keyframes rainbow-text-flow {
+  0% { background-position: 0% center; }
+  100% { background-position: 200% center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rainbow-text {
+    background: none;
+    -webkit-text-fill-color: var(--accent-light);
+    animation: none;
+  }
+}
+
 /* Flash highlight applied by useFlipAnimation when an item moves up after
    a refresh. The slide itself is a JS-driven transform; this class only
    provides the green pulse so the eye catches the move. */


### PR DESCRIPTION
Two related tweaks to the player-page live-update status pill.

### 1. Animated rainbow "Loading…"
The "Loading…" status was easy to miss (small muted accent + subtle pulse). Now a flowing **animated rainbow gradient** (`globals.css` `.rainbow-text`, mirroring the existing `.shimmer-green` technique; `prefers-reduced-motion` fallback to a static color).

### 2. Drop "Update available" at cooldown zero
Since the hook now auto-fires at zero (flips to phase `loading` in the same tick the countdown hits 0), the `cooldown && secondsRemaining === 0` → "Update available" branch no longer renders in normal use — it only survived as the brief parked state of a refresh that failed to land. Render **nothing** there instead of a stale prompt that reads as a manual action. "Next update: N min" is unchanged.

## Tests
- Loading pill asserts the `rainbow-text` class.
- New: `cooldown` + `secondsRemaining=0` renders **no** status pill.
- Frontend gate green: ESLint, 107 jest, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)