### PR TITLE
perf(player): prefetch battle-history in parallel with the profile fetch (cut T1)

### DIFF
--- a/client/app/components/BattleHistoryCard.tsx
+++ b/client/app/components/BattleHistoryCard.tsx
@@ -79,6 +79,46 @@ const MODES: Mode[] = ['random', 'ranked', 'combined'];
 const RANKED_PENDING_RETRY_DELAY_MS = 2000;
 const RANKED_PENDING_RETRY_LIMIT = 6;
 
+// Canonical battle-history fetch URL + cache key. Shared by the card's own
+// fetch and PlayerRouteView's parallel prefetch so they dedupe onto the same
+// in-flight request (sharedJsonFetch keys on cacheKey). Keep these in lockstep —
+// if they drift, the prefetch silently becomes a duplicate request instead of a
+// dedup (guarded by a test).
+export const BATTLE_HISTORY_FETCH_TTL_MS = 60_000;
+
+export const battleHistoryFetchUrl = (
+    playerName: string, realm: string, window: string = 'week', mode: string = 'random',
+): string =>
+    `/api/player/${encodeURIComponent(playerName)}/battle-history/`
+    + `?window=${window}&mode=${mode}`
+    + `&realm=${encodeURIComponent(realm)}`;
+
+export const battleHistoryCacheKey = (
+    playerName: string, realm: string,
+    window: string = 'week', mode: string = 'random', cacheBust: number = 0, refreshNonce: number = 0,
+): string => `battle-history:${playerName}:${realm}:${window}:${mode}:${cacheBust}:${refreshNonce}`;
+
+/**
+ * Eagerly fire the initial (week / random) battle-history fetch so it runs in
+ * PARALLEL with the player-profile fetch, instead of starting only after the
+ * profile resolves and PlayerDetail mounts the card. The card's own first fetch
+ * dedupes onto this via the shared cacheKey (or hits the warm 60s cache), so it
+ * costs no extra request — it just moves the battle-history round-trip off the
+ * serial critical path, shaving it off T1.
+ *
+ * Fire-and-forget: this runs before we know `is_hidden` (hidden players never
+ * render the card), but the request is cheap and the card handles its own
+ * errors/404 — so do NOT gate this on is_hidden (that info isn't here yet).
+ */
+export const prefetchBattleHistory = (playerName: string, realm: string): void => {
+    void fetchSharedJson<BattleHistoryPayload>(battleHistoryFetchUrl(playerName, realm), {
+        label: 'BattleHistoryCard:week:random',
+        ttlMs: BATTLE_HISTORY_FETCH_TTL_MS,
+        cacheKey: battleHistoryCacheKey(playerName, realm),
+        responseHeaders: ['X-Ranked-Observation-Pending'],
+    }).catch(() => { /* the card re-fetches + surfaces errors on mount */ });
+};
+
 interface BattleHistoryCardProps {
     playerName: string;
     realm: string;
@@ -552,13 +592,13 @@ const BattleHistoryCard: React.FC<BattleHistoryCardProps> = ({
         setLoading(true);
 
         const fetchOnce = (cacheBust: number = 0) => {
-            const url = `/api/player/${encodeURIComponent(playerName)}/battle-history/`
-                + `?window=${window}&mode=${mode}`
-                + `&realm=${encodeURIComponent(realm)}`;
+            // Shared builders so the initial (week/random) fetch dedupes onto
+            // PlayerRouteView's parallel prefetch via an identical cacheKey.
+            const url = battleHistoryFetchUrl(playerName, realm, window, mode);
             fetchSharedJson<BattleHistoryPayload>(url, {
                 label: `BattleHistoryCard:${window}:${mode}`,
-                ttlMs: 60_000,
-                cacheKey: `battle-history:${playerName}:${realm}:${window}:${mode}:${cacheBust}:${refreshNonce}`,
+                ttlMs: BATTLE_HISTORY_FETCH_TTL_MS,
+                cacheKey: battleHistoryCacheKey(playerName, realm, window, mode, cacheBust, refreshNonce),
                 responseHeaders: ['X-Ranked-Observation-Pending'],
             })
                 .then(({ data, headers }) => {

--- a/client/app/components/PlayerRouteView.tsx
+++ b/client/app/components/PlayerRouteView.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import PlayerDetail from './PlayerDetail';
+import { prefetchBattleHistory } from './BattleHistoryCard';
 import type { PlayerData } from './entityTypes';
 import { buildClanPath, buildPlayerPath } from '../lib/entityRoutes';
 import { PLAYER_ROUTE_FETCH_TTL_MS } from '../lib/playerRouteFetch';
@@ -50,6 +51,13 @@ const PlayerRouteView: React.FC<PlayerRouteViewProps> = ({ playerName }) => {
         const loadPlayer = async () => {
             setIsLoading(true);
             setError('');
+
+            // Kick the battle-history fetch in PARALLEL with the profile fetch.
+            // The card mounts only after the profile resolves + PlayerDetail
+            // renders, so without this its fetch starts serially after the
+            // profile; firing it here moves that round-trip off the critical
+            // path. The card's own fetch dedupes onto this (shared cacheKey).
+            prefetchBattleHistory(playerName, realm);
 
             try {
                 const { data, headers } = await fetchSharedJson<PlayerData>(withRealm(`/api/player/${encodeURIComponent(playerName)}/`, realm), {

--- a/client/app/components/__tests__/BattleHistoryCard.test.tsx
+++ b/client/app/components/__tests__/BattleHistoryCard.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
-import BattleHistoryCard, { type BattleHistoryPayload } from '../BattleHistoryCard';
+import BattleHistoryCard, {
+    type BattleHistoryPayload,
+    battleHistoryCacheKey,
+    battleHistoryFetchUrl,
+    prefetchBattleHistory,
+    BATTLE_HISTORY_FETCH_TTL_MS,
+} from '../BattleHistoryCard';
 import { fetchSharedJson } from '../../lib/sharedJsonFetch';
 
 jest.mock('../../lib/sharedJsonFetch', () => ({
@@ -463,5 +469,46 @@ describe('BattleHistoryCard', () => {
         });
         // Pills still reachable.
         expect(screen.getByRole('button', { name: /^Random$/ })).toBeInTheDocument();
+    });
+});
+
+describe('battle-history prefetch dedupe contract', () => {
+    beforeEach(() => {
+        mockFetchSharedJson.mockReset();
+    });
+
+    it('builders produce the canonical week/random url + cache key', () => {
+        // Drift guard: PlayerRouteView's prefetch and the card's first fetch must
+        // share these EXACT strings, or the prefetch becomes a duplicate request.
+        expect(battleHistoryFetchUrl('lil_boots', 'na')).toBe(
+            '/api/player/lil_boots/battle-history/?window=week&mode=random&realm=na');
+        expect(battleHistoryCacheKey('lil_boots', 'na')).toBe(
+            'battle-history:lil_boots:na:week:random:0:0');
+    });
+
+    it('prefetchBattleHistory fires the canonical week/random fetch', () => {
+        mockFetchSharedJson.mockResolvedValueOnce({ data: buildPayload(), headers: {} });
+        prefetchBattleHistory('lil_boots', 'na');
+        expect(mockFetchSharedJson).toHaveBeenCalledWith(
+            '/api/player/lil_boots/battle-history/?window=week&mode=random&realm=na',
+            expect.objectContaining({
+                ttlMs: BATTLE_HISTORY_FETCH_TTL_MS,
+                cacheKey: 'battle-history:lil_boots:na:week:random:0:0',
+            }),
+        );
+    });
+
+    it("the card's first fetch uses the same url + cache key (so the prefetch dedupes onto it)", async () => {
+        resolveWith(buildPayload());
+        render(<BattleHistoryCard playerName="lil_boots" realm="na" />);
+        await waitFor(() => {
+            expect(mockFetchSharedJson).toHaveBeenCalled();
+        });
+        const [url, opts] = mockFetchSharedJson.mock.calls[0];
+        expect(url).toBe('/api/player/lil_boots/battle-history/?window=week&mode=random&realm=na');
+        expect(opts).toEqual(expect.objectContaining({
+            cacheKey: 'battle-history:lil_boots:na:week:random:0:0',
+            ttlMs: BATTLE_HISTORY_FETCH_TTL_MS,
+        }));
     });
 });

--- a/client/app/components/__tests__/PlayerRouteViewWarmup.test.tsx
+++ b/client/app/components/__tests__/PlayerRouteViewWarmup.test.tsx
@@ -182,12 +182,23 @@ describe('PlayerRouteView tab warmup smoke', () => {
             label: 'Player Player One',
             ttlMs: 1500,
         }));
+        // Battle-history is prefetched in PARALLEL — fired before the player
+        // payload resolves, not serially after PlayerDetail mounts the card.
+        expect(mockFetchSharedJson).toHaveBeenCalledWith(
+            '/api/player/Player%20One/battle-history/?window=week&mode=random&realm=na',
+            expect.objectContaining({
+                ttlMs: 60000,
+                cacheKey: 'battle-history:Player One:na:week:random:0:0',
+            }),
+        );
 
         await act(async () => {
             jest.advanceTimersByTime(250);
         });
 
-        expect(mockFetchSharedJson).toHaveBeenCalledTimes(1);
+        // Profile + parallel battle-history prefetch fired; tab warmup has NOT
+        // yet (it still waits for the player payload to resolve).
+        expect(mockFetchSharedJson).toHaveBeenCalledTimes(2);
 
         await act(async () => {
             resolvePlayerRoute?.({ data: playerRoutePayload, headers: {} });


### PR DESCRIPTION
## Problem
The battle-history card mounts only **after** the profile fetch resolves and `PlayerDetail` renders — so its fetch ran **serially after** the profile, adding the battle-history round-trip to **T1** (time-to-battle-history-visible). Profiling (14 cold players) put T1 at ~1.0s p50, with the battle-history API itself ~140ms.

## Fix
Fire the battle-history fetch **in parallel** from `PlayerRouteView.loadPlayer` (alongside the profile fetch). The card's own first fetch **dedupes onto it** via a shared `cacheKey` — `sharedJsonFetch` keys both its in-flight and settled (60s TTL) caches on `cacheKey`, so the card joins the in-flight promise (or warm cache) instead of firing a second request. Net: no extra request, the round-trip just moves off the serial critical path.

- `BattleHistoryCard`: export canonical `battleHistoryFetchUrl` / `battleHistoryCacheKey` builders + `prefetchBattleHistory()`; `fetchOnce` now builds its URL/cacheKey via the same helpers so the initial week/random fetch shares the prefetch key.
- `PlayerRouteView`: `prefetchBattleHistory(playerName, realm)` at the top of `loadPlayer` (inside the `[playerName, realm]` effect, so SPA navigation re-fires it for the new player). Fire-and-forget; runs before `is_hidden` is known (cheap, card handles its own errors/404).

Expected: **~150–300ms off T1 p50** (I'll re-profile after deploy to confirm).

## Tests
- `PlayerRouteViewWarmup`: asserts the battle-history fetch fires **before** the player payload resolves (parallel, not serial) and tab-warmup still waits.
- `BattleHistoryCard`: cacheKey/URL drift guard (the prefetch & card must share the exact key) + the card's first fetch uses the same URL/key as the prefetch (so they dedupe).
- Frontend gate green: ESLint, 111 jest, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)