### PR TITLE
fix(battle-history): suppress nonsense WR delta on lifetime/rollup skew

### DIFF
--- a/server/warships/tests/test_incremental_battles.py
+++ b/server/warships/tests/test_incremental_battles.py
@@ -2052,6 +2052,43 @@ class BattleHistoryEndpointTests(TestCase):
         # Period: 1 win in 4 battles. Prior: 55/96 = 57.3%. Delta: 56 - 57.3 = -1.3.
         self.assertEqual(ship["delta_win_rate"], -1.3)
 
+    def test_delta_suppressed_when_snapshot_skew_makes_prior_impossible(self):
+        """Regression for the Bremen -83% delta: when the randoms-only
+        lifetime snapshot (battles_json) lags the live rollup, subtracting
+        the period from lifetime can yield an impossible prior (more wins
+        than battles). Lifetime stays visible; the delta is suppressed.
+        """
+        # Lifetime snapshot: 8 battles / 4 wins (50%). Rollup period: 5
+        # battles / 0 wins. Prior = 8-5 = 3 battles but 4-0 = 4 wins —
+        # impossible (would compute a 133.3% prior WR → -83.3pp delta).
+        self.player.pvp_battles = 1000
+        self.player.pvp_wins = 530
+        self.player.battles_json = [
+            {"ship_id": 42, "ship_name": "Bremen", "ship_tier": 10,
+             "ship_type": "Cruiser",
+             "pvp_battles": 8, "wins": 4, "losses": 4},
+        ]
+        self.player.save()
+        self._seed_daily_rows({
+            42: {"battles": 5, "wins": 0, "losses": 5, "ship_name": "Bremen"},
+        })
+        with mock.patch.dict(
+            "os.environ",
+            {"BATTLE_HISTORY_API_ENABLED": "1"},
+            clear=False,
+        ):
+            response = self.client.get(
+                "/api/player/api_test/battle-history/?days=7&mode=random",
+            )
+        ship = response.json()["by_ship"][0]
+        self.assertEqual(ship["win_rate"], 0.0)
+        # Valid career number is preserved.
+        self.assertEqual(ship["lifetime_battles"], 8)
+        self.assertEqual(ship["lifetime_win_rate"], 50.0)
+        # Nonsense delta suppressed; not a new ship (real prior history).
+        self.assertIsNone(ship["delta_win_rate"])
+        self.assertFalse(ship["is_new_ship"])
+
     def test_overall_lifetime_delta_uses_player_aggregates(self):
         """Phase 4.6: totals tile lifetime delta uses player's PvP aggregate."""
         self.player.pvp_battles = 1000

--- a/server/warships/views.py
+++ b/server/warships/views.py
@@ -835,11 +835,23 @@ def _build_battle_history_payload_24h(player, mode: str) -> dict:
                     s["lifetime_battles"] = lifetime["battles"]
                     s["lifetime_win_rate"] = lifetime_wr_now
             else:
-                prior_wr = round(100.0 * prior_wins / prior_battles, 1)
                 s["lifetime_battles"] = lifetime["battles"]
                 s["lifetime_win_rate"] = lifetime_wr_now
-                s["delta_win_rate"] = round(lifetime_wr_now - prior_wr, 1)
                 s["is_new_ship"] = False
+                # Sync skew between the randoms-only lifetime snapshot
+                # (battles_json, a refresh-cadence snapshot) and the live
+                # rollup can make the subtracted prior impossible — more
+                # wins than battles, or negative — when the snapshot
+                # predates some of the period's recorded battles. That
+                # would yield a >100% prior WR and a nonsense delta (e.g.
+                # lifetime 8b/4w minus period 5b/0w → prior 3b/4w → -83pp).
+                # Keep the valid lifetime WR but suppress the delta until
+                # the snapshot catches up.
+                if 0 <= prior_wins <= prior_battles:
+                    prior_wr = round(100.0 * prior_wins / prior_battles, 1)
+                    s["delta_win_rate"] = round(lifetime_wr_now - prior_wr, 1)
+                else:
+                    s["delta_win_rate"] = None
         else:
             s["lifetime_battles"] = None
             s["lifetime_win_rate"] = None
@@ -871,9 +883,14 @@ def _build_battle_history_payload_24h(player, mode: str) -> dict:
             and totals_random_battles > 0):
         prior_battles_overall = lifetime_battles_overall - totals_random_battles
         prior_wins_overall = lifetime_wins_overall - totals_random_wins
+        # Same sync-skew guard as the per-ship delta: an impossible prior
+        # (wins outside [0, battles]) means the lifetime snapshot and the
+        # rollup disagree; suppress the delta rather than show a nonsense
+        # value.
         prior_overall_wr = round(
             100.0 * prior_wins_overall / prior_battles_overall, 1
-        ) if prior_battles_overall > 0 else None
+        ) if (prior_battles_overall > 0
+              and 0 <= prior_wins_overall <= prior_battles_overall) else None
         delta_overall_wr = round(
             lifetime_overall_wr - prior_overall_wr, 1
         ) if prior_overall_wr is not None and lifetime_overall_wr is not None else None
@@ -1113,11 +1130,23 @@ def _build_battle_history_payload(player, period: str, windows: int,
                     s["lifetime_battles"] = lifetime["battles"]
                     s["lifetime_win_rate"] = lifetime_wr_now
             else:
-                prior_wr = round(100.0 * prior_wins / prior_battles, 1)
                 s["lifetime_battles"] = lifetime["battles"]
                 s["lifetime_win_rate"] = lifetime_wr_now
-                s["delta_win_rate"] = round(lifetime_wr_now - prior_wr, 1)
                 s["is_new_ship"] = False
+                # Sync skew between the randoms-only lifetime snapshot
+                # (battles_json, a refresh-cadence snapshot) and the live
+                # rollup can make the subtracted prior impossible — more
+                # wins than battles, or negative — when the snapshot
+                # predates some of the period's recorded battles. That
+                # would yield a >100% prior WR and a nonsense delta (e.g.
+                # lifetime 8b/4w minus period 5b/0w → prior 3b/4w → -83pp).
+                # Keep the valid lifetime WR but suppress the delta until
+                # the snapshot catches up.
+                if 0 <= prior_wins <= prior_battles:
+                    prior_wr = round(100.0 * prior_wins / prior_battles, 1)
+                    s["delta_win_rate"] = round(lifetime_wr_now - prior_wr, 1)
+                else:
+                    s["delta_win_rate"] = None
         else:
             # No lifetime row, zero lifetime battles, or sync skew between
             # battles_json (a refresh-cadence snapshot) and the rollup
@@ -1160,9 +1189,14 @@ def _build_battle_history_payload(player, period: str, windows: int,
     ):
         prior_battles_overall = lifetime_battles_overall - totals_random_battles
         prior_wins_overall = lifetime_wins_overall - totals_random_wins
+        # Same sync-skew guard as the per-ship delta: an impossible prior
+        # (wins outside [0, battles]) means the lifetime snapshot and the
+        # rollup disagree; suppress the delta rather than show a nonsense
+        # value.
         prior_overall_wr = round(
             100.0 * prior_wins_overall / prior_battles_overall, 1
-        ) if prior_battles_overall > 0 else None
+        ) if (prior_battles_overall > 0
+              and 0 <= prior_wins_overall <= prior_battles_overall) else None
         delta_overall_wr = round(
             lifetime_overall_wr - prior_overall_wr, 1
         ) if prior_overall_wr is not None and lifetime_overall_wr is not None else None


### PR DESCRIPTION
## Problem

The per-ship and totals **delta** columns in the battle-history table compute a prior-state win rate by subtracting the live `PlayerDailyShipStats` rollup's session battles from the randoms-only `Player.battles_json` lifetime snapshot. The snapshot is refreshed on a cadence and can lag the live rollup, so the subtraction can yield an **impossible prior — more wins than battles**.

Real case (`lil_boots` / Bremen): lifetime `8 battles / 4 wins`, session `5 / 0` → prior `3 battles / 4 wins` → 133.3% prior WR → `delta = 50.0 − 133.3 = −83.3%`.

The existing guard checked the battles side (`lifetime >= session`) but never that the resulting wins stayed within `[0, battles]`.

## Fix

Add a `0 <= prior_wins <= prior_battles` guard at all four delta sites (per-ship + totals, in both the 24h and period builders). On skew the valid career WR stays visible and the delta is suppressed (renders `—`), self-healing on the next snapshot refresh.

## Tests

Added a regression test using the exact Bremen inputs. Full `test_incremental_battles.py` green (133 passed).

## Deploy

Already deployed to production (release `20260601101455`) and verified live — Bremen now returns `delta_win_rate: null` instead of `−83.3%`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)