### PR TITLE
feat(analytics): track landing, treemap, ship-page, and footer events in Umami

### DIFF
--- a/client/app/components/Footer.tsx
+++ b/client/app/components/Footer.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faReddit } from '@fortawesome/free-brands-svg-icons';
 import { buildPlayerPath } from '../lib/entityRoutes';
+import { trackEvent } from '../lib/umami';
 import StreamerSubmissionModal from './StreamerSubmissionModal';
 
 const Footer: React.FC = () => {
@@ -14,7 +15,11 @@ const Footer: React.FC = () => {
             <div className="space-y-2 px-4 leading-5">
                 <p>
                     Battlestats v{process.env.NEXT_PUBLIC_APP_VERSION} by{' '}
-                    <Link href={buildPlayerPath('lil_boots', 'na')} className="text-[var(--accent-mid)] underline-offset-2 hover:text-[var(--accent-dark)] hover:underline">
+                    <Link
+                        href={buildPlayerPath('lil_boots', 'na')}
+                        onClick={() => trackEvent('footer-lil-boots', { realm: 'na' })}
+                        className="text-[var(--accent-mid)] underline-offset-2 hover:text-[var(--accent-dark)] hover:underline"
+                    >
                         lil_boots
                     </Link>
                     {' '}

--- a/client/app/components/PlayerSearch.tsx
+++ b/client/app/components/PlayerSearch.tsx
@@ -25,6 +25,7 @@ import useClanHydrationPoll from './useClanHydrationPoll';
 import { useTheme } from '../context/ThemeContext';
 import { useRealm } from '../context/RealmContext';
 import { withRealm } from '../lib/realmParams';
+import { trackEvent } from '../lib/umami';
 import wrColor from '../lib/wrColor';
 
 const LoadingPanel: React.FC<{ label: string; minHeight?: number }> = ({ label, minHeight = 220 }) => (
@@ -522,7 +523,7 @@ const PlayerSearch: React.FC = () => {
                                 <h3 className="mr-2 text-sm font-semibold uppercase tracking-wide text-[var(--accent-mid)]">Players</h3>
                                 <button
                                     type="button"
-                                    onClick={() => { setPlayerMode('recent'); setPlayerBestSort('overall'); }}
+                                    onClick={() => { if (playerMode !== 'recent') { setPlayerMode('recent'); setPlayerBestSort('overall'); trackEvent('landing-filter', { entity: 'player', mode: 'recent', realm }); } }}
                                     className={`inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-semibold uppercase tracking-wide transition-colors ${playerMode === 'recent' ? 'border-[var(--accent-mid)] bg-[var(--accent-mid)] text-white' : 'border-[var(--border)] bg-[var(--bg-page)] text-[var(--accent-mid)] hover:bg-[var(--accent-faint)]'}`}
                                     aria-pressed={playerMode === 'recent'}
                                 >
@@ -530,7 +531,7 @@ const PlayerSearch: React.FC = () => {
                                 </button>
                                 <button
                                     type="button"
-                                    onClick={() => setPlayerMode('best')}
+                                    onClick={() => { if (playerMode !== 'best') { setPlayerMode('best'); trackEvent('landing-filter', { entity: 'player', mode: 'best', realm }); } }}
                                     className={`inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-semibold uppercase tracking-wide transition-colors ${playerMode === 'best' ? 'border-[var(--accent-mid)] bg-[var(--accent-mid)] text-white' : 'border-[var(--border)] bg-[var(--bg-page)] text-[var(--accent-mid)] hover:bg-[var(--accent-faint)]'}`}
                                     aria-pressed={playerMode === 'best'}
                                 >
@@ -548,7 +549,7 @@ const PlayerSearch: React.FC = () => {
                                             {i > 0 && <span className="text-xs text-[var(--text-secondary)]">&middot;</span>}
                                             <button
                                                 type="button"
-                                                onClick={() => setPlayerBestSort(sort)}
+                                                onClick={() => { if (playerBestSort !== sort) { setPlayerBestSort(sort); trackEvent('landing-best-sort', { entity: 'player', sort, realm }); } }}
                                                 disabled={!showPlayerBestSortBar}
                                                 tabIndex={showPlayerBestSortBar ? 0 : -1}
                                                 className={`text-sm font-medium transition-colors disabled:cursor-default ${playerBestSort === sort ? 'text-[var(--accent-mid)] underline decoration-[var(--accent-mid)] underline-offset-4' : 'text-[var(--text-secondary)] hover:text-[var(--accent-mid)] hover:underline hover:underline-offset-4'}`}
@@ -618,7 +619,7 @@ const PlayerSearch: React.FC = () => {
                                 <h3 className="mr-2 text-sm font-semibold uppercase tracking-wide text-[var(--accent-mid)]">Active Clans</h3>
                                 <button
                                     type="button"
-                                    onClick={() => setClanMode('best')}
+                                    onClick={() => { if (clanMode !== 'best') { setClanMode('best'); trackEvent('landing-filter', { entity: 'clan', mode: 'best', realm }); } }}
                                     className={`inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-semibold uppercase tracking-wide transition-colors ${clanMode === 'best' ? 'border-[var(--accent-mid)] bg-[var(--accent-mid)] text-white' : 'border-[var(--border)] bg-[var(--bg-page)] text-[var(--accent-mid)] hover:bg-[var(--accent-faint)]'}`}
                                     aria-pressed={clanMode === 'best'}
                                 >
@@ -626,7 +627,7 @@ const PlayerSearch: React.FC = () => {
                                 </button>
                                 <button
                                     type="button"
-                                    onClick={() => { setClanMode('recent'); setClanBestSort('overall'); }}
+                                    onClick={() => { if (clanMode !== 'recent') { setClanMode('recent'); setClanBestSort('overall'); trackEvent('landing-filter', { entity: 'clan', mode: 'recent', realm }); } }}
                                     className={`inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-semibold uppercase tracking-wide transition-colors ${clanMode === 'recent' ? 'border-[var(--accent-mid)] bg-[var(--accent-mid)] text-white' : 'border-[var(--border)] bg-[var(--bg-page)] text-[var(--accent-mid)] hover:bg-[var(--accent-faint)]'}`}
                                     aria-pressed={clanMode === 'recent'}
                                 >
@@ -644,7 +645,7 @@ const PlayerSearch: React.FC = () => {
                                             {i > 0 && <span className="text-xs text-[var(--text-secondary)]">&middot;</span>}
                                             <button
                                                 type="button"
-                                                onClick={() => setClanBestSort(sort)}
+                                                onClick={() => { if (clanBestSort !== sort) { setClanBestSort(sort); trackEvent('landing-best-sort', { entity: 'clan', sort, realm }); } }}
                                                 disabled={!showClanBestSortBar}
                                                 tabIndex={showClanBestSortBar ? 0 : -1}
                                                 className={`text-sm font-medium transition-colors disabled:cursor-default ${clanBestSort === sort ? 'text-[var(--accent-mid)] underline decoration-[var(--accent-mid)] underline-offset-4' : 'text-[var(--text-secondary)] hover:text-[var(--accent-mid)] hover:underline hover:underline-offset-4'}`}

--- a/client/app/components/RealmTopShipsTreemapSVG.tsx
+++ b/client/app/components/RealmTopShipsTreemapSVG.tsx
@@ -254,7 +254,7 @@ const RealmTopShipsTreemapSVG: React.FC = () => {
                             <button
                                 key={m}
                                 type="button"
-                                onClick={() => setMode(m)}
+                                onClick={() => { if (mode !== m) { setMode(m); trackEvent('treemap-mode', { mode: m, realm }); } }}
                                 aria-pressed={mode === m}
                                 className={`rounded px-2 py-0.5 transition-colors ${
                                     mode === m

--- a/client/app/components/ShipRouteView.tsx
+++ b/client/app/components/ShipRouteView.tsx
@@ -108,6 +108,11 @@ const ShipRouteView: React.FC<ShipRouteViewProps> = ({ shipSlug }) => {
                 if (!cancelled) {
                     setData(payload);
                     setIsLoading(false);
+                    trackEvent('ship-page-view', {
+                        ship_id: shipId,
+                        ship_name: payload.ship.name,
+                        realm,
+                    });
                 }
             })
             .catch(() => {

--- a/client/app/components/__tests__/Footer.test.tsx
+++ b/client/app/components/__tests__/Footer.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Footer from '../Footer';
+
+const trackEventMock = jest.fn();
+jest.mock('../../lib/umami', () => ({
+    trackEvent: (...args: unknown[]) => trackEventMock(...args),
+}));
+
+describe('Footer creator-link tracking', () => {
+    beforeEach(() => {
+        trackEventMock.mockReset();
+    });
+
+    it('fires a footer-lil-boots umami event when the creator link is clicked', () => {
+        render(<Footer />);
+
+        const creatorLink = screen.getByRole('link', { name: 'lil_boots' });
+        expect(creatorLink).toHaveAttribute('href', '/player/lil_boots?realm=na');
+
+        fireEvent.click(creatorLink);
+        expect(trackEventMock).toHaveBeenCalledWith('footer-lil-boots', { realm: 'na' });
+    });
+});

--- a/client/app/components/__tests__/PlayerSearch.test.tsx
+++ b/client/app/components/__tests__/PlayerSearch.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import PlayerSearch from '../PlayerSearch';
 
 const pushMock = jest.fn();
+const trackEventMock = jest.fn();
 const capturedPlayerDetailProps: { current: null | Record<string, unknown> } = { current: null };
 
 const buildJsonResponse = (payload: unknown) => ({
@@ -310,11 +311,16 @@ jest.mock('../LandingClanSVG', () => {
     };
 });
 
+jest.mock('../../lib/umami', () => ({
+    trackEvent: (...args: unknown[]) => trackEventMock(...args),
+}));
+
 describe('PlayerSearch landing efficiency icon', () => {
     let consoleErrorSpy: jest.SpyInstance;
 
     beforeEach(() => {
         pushMock.mockReset();
+        trackEventMock.mockReset();
         capturedPlayerDetailProps.current = null;
         window.history.replaceState({}, '', '/');
         jest.useRealTimers();
@@ -344,6 +350,39 @@ describe('PlayerSearch landing efficiency icon', () => {
     const switchToBestMode = async () => {
         fireEvent.click(await getPlayerBestButton());
     };
+
+    it('tracks landing-filter and landing-best-sort umami events for the player toolbar', async () => {
+        render(<PlayerSearch />);
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { name: 'Players' })).toBeInTheDocument();
+        });
+
+        // Recent is the default; switching to Best fires a player landing-filter.
+        await switchToBestMode();
+        expect(trackEventMock).toHaveBeenCalledWith(
+            'landing-filter', expect.objectContaining({ entity: 'player', mode: 'best' }));
+
+        // Selecting a Best sub-sort fires landing-best-sort with the chosen sort.
+        const rankedSort = within(screen.getByTestId('player-best-sort-bar'))
+            .getByRole('button', { name: 'Ranked' });
+        fireEvent.click(rankedSort);
+        expect(trackEventMock).toHaveBeenCalledWith(
+            'landing-best-sort', expect.objectContaining({ entity: 'player', sort: 'ranked' }));
+
+        // Re-clicking the already-active mode does not double-fire.
+        trackEventMock.mockReset();
+        fireEvent.click(await getPlayerBestButton());
+        expect(trackEventMock).not.toHaveBeenCalledWith(
+            'landing-filter', expect.objectContaining({ entity: 'player', mode: 'best' }));
+    });
+
+    it('tracks a landing-filter umami event for the clan toolbar', async () => {
+        render(<PlayerSearch />);
+        const clanRecentButton = await getClanRecentButton();
+        fireEvent.click(clanRecentButton);
+        expect(trackEventMock).toHaveBeenCalledWith(
+            'landing-filter', expect.objectContaining({ entity: 'clan', mode: 'recent' }));
+    });
 
     it('renders the sigma only for Expert landing rows while preserving existing landing icons', async () => {
         render(<PlayerSearch />);


### PR DESCRIPTION
## Summary

Adds Umami custom-event tracking across the landing/discovery surfaces so the realtime/Events report covers the funnel. Analytics-only — no API contract, payload, or server changes.

| Event | Fires on | Payload |
|---|---|---|
| `treemap-ship` | ship-tile click *(pre-existing, unchanged)* | `{ ship_id, ship_name, mode, realm }` |
| `treemap-mode` | Random/Ranked toggle on the realm top-ships treemap | `{ mode, realm }` |
| `ship-page-view` | visiting a `/ship/<id>` page | `{ ship_id, ship_name, realm }` |
| `landing-filter` | player (Recent/Best) & clan (Best/Recent) toolbars | `{ entity, mode, realm }` |
| `landing-best-sort` | Best sub-filters for both player and clan toolbars | `{ entity, sort, realm }` |
| `footer-lil-boots` | creator link in the global footer | `{ realm: 'na' }` |

All toggles guard against re-firing on the already-active option; `ship-page-view` fires once per successful load behind the existing cancellation guard. Payloads carry `realm` for low-cardinality breakdowns, per the `umami.ts` convention.

## Test coverage

- Added `trackEvent` assertions for `landing-filter` and `landing-best-sort` in `PlayerSearch.test.tsx` (27 pass).
- New `Footer.test.tsx` covers `footer-lil-boots`.
- `treemap-mode` and `ship-page-view` left uncovered — no d3/router test harness exists for `RealmTopShipsTreemapSVG`/`ShipRouteView` (the pre-existing `treemap-ship` is untested for the same reason); standing one up for two side-effects isn't proportionate.

## Verification

- `tsc` + ESLint clean on all touched files; `npm run build` succeeds.
- **Already deployed to production** (release `20260606010537`, VERSION 1.16.7 unchanged). Grepped the live served bundles — all five new event names present (4 in landing chunks, `ship-page-view` in the `/ship` route chunk); umami tracker loads on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)