### PR TITLE
feat(analytics): clan-page toggle + share events, name-baked for realtime clarity

### DIFF
--- a/agents/doc_registry.json
+++ b/agents/doc_registry.json
@@ -1828,6 +1828,32 @@
                 "phase7c-shipped-and-30-day-coverage-stable"
             ]
         },
+        "agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md": {
+            "kind": "runbook",
+            "status": "active",
+            "lifecycle": "evergreen",
+            "section": "operations",
+            "owner": "platform",
+            "aliases": [
+                "rollup durability",
+                "battle history rollup durability",
+                "daily ship stats self-heal",
+                "rollup reconciliation"
+            ],
+            "tags": [
+                "battle history",
+                "rollup",
+                "durability",
+                "self-heal",
+                "reconciliation",
+                "brin index",
+                "playerdailyshipstats",
+                "observability"
+            ],
+            "archive_on": [
+                "rollup-durability-superseded"
+            ]
+        },
         "agents/contracts/upstream/wows-ships-badges.yaml": {
             "kind": "contract",
             "status": "active",

--- a/agents/runbooks/ops-env-reference.md
+++ b/agents/runbooks/ops-env-reference.md
@@ -33,6 +33,9 @@ Enrichment:
 Battle-history pipeline (phased gates, all default 0):
 - `BATTLE_HISTORY_CAPTURE_ENABLED` (write BattleObservation/BattleEvent as a side-effect of `update_battle_data`)
 - `BATTLE_HISTORY_ROLLUP_ENABLED` + `_HOUR`/`_MINUTE` (4/30) (fill PlayerDailyShipStats + nightly rebuild)
+- `BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS` (3) — trailing-window size the nightly sweeper rebuilds (self-heal); `1` = legacy yesterday-only. See `runbook-battle-history-rollup-durability-2026-06-06.md`.
+- `BATTLE_HISTORY_RECONCILE_ENABLED` (0) — gates the alert-only rollup reconciliation task; **independent** of `BATTLE_HISTORY_ROLLUP_ENABLED` (so it can detect rollup-off / holes)
+- `BATTLE_HISTORY_RECONCILE_AUDIT_DAYS` (30) — audit window the reconciliation task scans
 - `BATTLE_HISTORY_API_ENABLED` (exposes `GET /api/player/<name>/battle-history?days=N`, 404 when off)
 - `BATTLE_HISTORY_RANKED_CAPTURE_ENABLED` + `_REALMS` (`na`) (third WG call `seasons/shipstats/`, ranked-mode events)
 - `BATTLE_TRACKING_PLAYER_NAMES`/`_POLL_SECONDS` (60) — incremental-battle PoC dispatcher

--- a/agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
+++ b/agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
@@ -1,0 +1,199 @@
+# Runbook: Battle-History Rollup Durability
+
+_Created: 2026-06-06_
+_Context: Battle-history data is continuously ingested into `BattleEvent`, and a derived calendrical layer (`PlayerDailyShipStats` → weekly/monthly/yearly) is rebuilt from it. People now rely on this data being current and durable, but the derived layer can silently drift from the source of truth and nothing detects it. This runbook closes the durability drift mode and makes it observable._
+_Status: Code landed on branch `feat/battle-history-rollup-durability` (sweeper trailing window, reconciliation, BRIN migration 0063, ops check script, tests — full backend release gate + new suites green on SQLite and Postgres). Production rollout (Step-0 gate verification + deploy + flag flips) is the remaining operator step — gates default off so the deploy is inert until flipped. This runbook is the durable spec._
+_Supersedes/extends: `runbook-battle-history-rollout-2026-04-28.md` (Phase 3 nightly sweeper), cross-links `runbook-battle-history-phase7-data-widening-2026-04-29.md` and `runbook-battle-observation-floor-2026-05-02.md`._
+
+## Purpose
+
+The nightly sweeper `roll_up_player_daily_ship_stats_task` (`server/warships/tasks.py:1738`) rebuilds `PlayerDailyShipStats` for **yesterday only**. That is correct *when the sweeper runs* — but it has no self-healing window, no reconciliation, and no observability. If the sweeper is disabled, the `background` worker is down, or Beat misfires for a stretch, the skipped days become **permanent holes**: the sweeper never revisits them and nothing reveals the gap. Recovery today is entirely manual.
+
+This runbook adds three bounded, low-risk durability mechanisms:
+
+1. **Trailing-window self-heal** — the sweeper rebuilds the last N days, not just yesterday.
+2. **Alert-only reconciliation** — a gate-independent daily task compares `BattleEvent` vs `PlayerDailyShipStats` battle counts per `(date, mode)` over an audit window and logs the discrepant dates.
+3. **A BRIN index + half-open range filter** on `BattleEvent.detected_at` so the widened scans stay cheap.
+
+## Mechanism (why holes are permanent today)
+
+`BattleEvent.detected_at` is `auto_now_add` (`server/warships/models.py:518`) — the DB `NOW()` at insert. **Real battle times are not stored.** Every event therefore lands on its **capture day**, not the day the battle was actually played.
+
+Consequences that shape this design:
+
+- **Yesterday is final.** Because events never arrive for older dates, once the sweeper rebuilds a day it is correct forever — *provided the sweeper ran that night*. This is what makes a small trailing-window rebuild safe and sufficient: re-running an already-correct day is a no-op-equivalent (idempotent delete+rebuild).
+- **A missed night is a permanent hole.** The sweeper only ever looks at yesterday, so a day skipped during an outage is never revisited.
+- **Recovery cannot re-poll.** WG has no historical per-match endpoint; the only source for rebuilding a past day is the `BattleEvent` rows already captured. Those rows persist forever (retention model in the rollout runbook), so any past day *can* be rebuilt from them — but only if something tells an operator the day is missing.
+
+## Scope
+
+**In scope (Gap A — durability):** self-heal + reconciliation + index. Bounded by design — auto-heal capped at N days; reconciliation only *alerts*; large repairs stay explicit and human-initiated (avoids the multi-day Python-load OOM ceiling the code already warns about at `incremental_battles.py:977-985`).
+
+**Out of scope (documented as follow-ups below):** Gap B accuracy (battle-time attribution), the DB-side rewrite of the daily rebuild, and reactivating the dormant weekly/monthly/yearly UI tiers.
+
+## Design
+
+### Data flow
+
+```
+BattleEvent (detected_at = capture day)
+        │  nightly sweeper (WIDENED)
+        ▼
+  ┌───────────────────────────────────────────────┐
+  │ roll_up_player_daily_ship_stats_task           │
+  │  • rebuild last N days (idempotent del+rebuild) │
+  │  • period tiers: rebuild once per DISTINCT      │
+  │    week/month/year anchor the window touches    │
+  └───────────────────────────────────────────────┘
+        ▼
+PlayerDailyShipStats  (+ weekly/monthly/yearly tiers)
+
+BattleEvent ──DB-side count──┐
+PlayerDailyShipStats ─count──┤
+        ▼
+  reconcile task (ALERT ONLY, own gate, independent of ROLLUP)
+        └─ logger.warning one line per hole → background worker log
+                  ▲
+   server/scripts/check_battle_history_rollup.sh (single-SSH, read-only)
+
+   rebuild_player_daily_ship_stats --since/--until (human-run repair) → PlayerDailyShipStats
+
+   BRIN index on detected_at → range-prunes both the sweeper and the reconcile scans
+```
+
+### 1. Trailing-window self-heal — `tasks.py` (`roll_up_player_daily_ship_stats_task`)
+
+- New env knob, house style: `lookback = int(os.getenv("BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS", "3"))`.
+- Build the date list `[yesterday-(lookback-1) .. yesterday]` and loop `rebuild_daily_ship_stats_for_date(d)` per date — the function is already idempotent (`incremental_battles.py:960`, deletes-then-rebuilds for the date).
+- **Period tiers — dedup, do not rebuild per day.** `rebuild_period_rollups_for_date(date)` (`incremental_battles.py:1356`) rebuilds week+month+year for a *single* date, so calling it per day across the window redoes the same week/month/year repeatedly (yearly is a full-YTD DB scan via `_aggregate_into_period_table`, `incremental_battles.py:1265`). Instead compute the **distinct per-tier anchors** the window touches using the existing `_week_start` / `_month_start` / `_year_start` helpers (`incremental_battles.py:1251-1262`), then call the lower-level `_aggregate_into_period_table(anchor, anchor_end, table)` **once per distinct `(anchor, tier)`**. Add a small wrapper `rebuild_period_rollups_for_window(dates)` in `incremental_battles.py` that owns the dedup + period-end/leap math (keeps it next to its existing owner, not in the task).
+- Preserve `target_date_iso` for manual single-date runs; when supplied, lookback collapses to 1 (one day, one period pass) — back-compatible with the existing manual/`rebuild` semantics.
+- Add a **single-run global lock** (`cache.add(_task_lock_key("roll_up_player_daily_ship_stats","global"), …)`, pattern at `tasks.py:1797-1826`) since the windowed run outlasts a single day and could overlap a slow prior run.
+- Keep the `BATTLE_HISTORY_ROLLUP_ENABLED` gate and the start/finish log lines; log a per-run summary `{days_rebuilt, periods_rebuilt, per-day result dicts}`.
+
+### 2. BRIN index + half-open range filter — guarded migration + `incremental_battles.py`
+
+- Add the BRIN index `battle_event_detected_brin` on `BattleEvent.detected_at` via a **guarded raw-SQL migration** (`CREATE INDEX CONCURRENTLY ... USING brin (detected_at)`), **not** as a `BattleEvent.Meta.indexes` entry. `detected_at` is monotonic (insert-time `NOW()`), so a BRIN index gives near-perfect range pruning at negligible write cost — the right index type for an append-mostly timestamp on a large/high-write table. **Why a guarded migration and not `Meta`:** the release gate builds the SQLite test DB straight from model `Meta` with `pytest --nomigrations` (`run_test_suite.sh`), and SQLite has no BRIN — declaring it in `Meta` would emit `USING brin` into the syncdb DDL and break the gate. This mirrors the established pg_trgm GIN index pattern (`migrations/0019_add_player_name_trigram_index.py`): the index lives only in the migration, guarded by `schema_editor.connection.vendor != 'postgresql'`, and a `NOTE` in `BattleEvent.Meta` documents it.
+- Replace `detected_at__date=target_date` with a **half-open naive-UTC datetime range** `detected_at__gte=day_start, detected_at__lt=next_day_start` at every day-filter site:
+  - `rebuild_daily_ship_stats_for_date` main query (`incremental_battles.py:986-988`) **and** the `events_seen` fallback count (`:1039-1041`),
+  - the management command's count query (`management/commands/rebuild_player_daily_ship_stats.py:63-65`),
+  - the reconciliation aggregates (below).
+  A range predicate uses the BRIN index; `__date=` (a function on the column) would not. The project is `USE_TZ=False`/UTC (`[[project_backend_utc_date_bucketing]]`), so the boundaries must be **naive UTC datetimes** (`datetime.combine(d, time.min)` and `+ timedelta(days=1)`).
+- Migration `0063_battle_event_detected_brin` runs `CREATE INDEX CONCURRENTLY` inside a `RunPython` with `atomic = False` — `BattleEvent` is large and high-write; a plain `CREATE INDEX` would take a disruptive lock. (`AddIndexConcurrently` was the original plan, but a vendor-guarded `RunPython` is what keeps the index out of SQLite/`--nomigrations` runs while still building concurrently on Postgres.)
+
+### 3. Reconciliation (alert-only) — `incremental_battles.py` + `tasks.py` + `signals.py`
+
+- `reconcile_daily_rollup_coverage(audit_days=30)` in `incremental_battles.py`:
+  - Per `(date, mode)` over the window, compare `SUM(BattleEvent.battles_delta)` vs `SUM(PlayerDailyShipStats.battles)`. Both are **DB-side aggregates** (`.values().annotate(Sum(...))`, the `_aggregate_into_period_table` pattern) — no Python row load. Bucket `BattleEvent` by `detected_at` date via the same half-open range (or `TruncDate`).
+  - Flag a date when `BattleEvent` has battles but `PlayerDailyShipStats` is missing or under-counts. **Ignore legitimately-zero days** (no events ⇒ no expected rows). Compare **per mode**: the daily layer carries both random and ranked, but the period tiers are randoms-only (`incremental_battles.py:1303`) — so reconcile the **daily** layer, never the period tiers.
+  - Return `{discrepancies: [{date, mode, be_battles, pds_battles, delta}], audit_days}`. **No writes.**
+- `reconcile_battle_history_rollup_task` in `tasks.py` (`@app.task(queue='background', **TASK_OPTS)`):
+  - **Gated by its own flag** `BATTLE_HISTORY_RECONCILE_ENABLED` (default `0`), **independent of `BATTLE_HISTORY_ROLLUP_ENABLED`**. This independence is the point: the reconcile task must be able to detect "rollup is off / holes exist" even when the rollup gate is down. Window from `BATTLE_HISTORY_RECONCILE_AUDIT_DAYS` (default `30`).
+  - `logger.warning` one line per discrepant date; `logger.info` a clean summary otherwise.
+- Register `battle-history-rollup-reconcile` PeriodicTask in `signals.py` (mirror the block at `signals.py:742-766`), crontab ~05:00 UTC — after the rollup window (04:30) completes.
+- Management command `reconcile_battle_history_rollup` (`--audit-days`, prints the report) for on-demand ops and local validation.
+
+### 4. Ops check script — `server/scripts/check_battle_history_rollup.sh`
+
+Single-SSH read-only report mirroring `scripts/check_enrichment_crawler.sh`: runs the reconciliation management command on the droplet and prints discrepant dates + the last rollup-task log summary. Read-only; never mutates. This is the external read that covers the reconcile task's own blind spot (a reconcile task that is itself down cannot warn about itself).
+
+## Production rollout — gate-state branch
+
+The rollout branches on the current value of `BATTLE_HISTORY_ROLLUP_ENABLED` on the droplet. CAPTURE + API appear live; ROLLUP is unconfirmed. **Resolve the gate state first** by either an operator confirmation or, with approval, a read-only check on the non-secret `.env` (do **not** dump `.env.secrets`):
+
+```bash
+grep -hoE 'BATTLE_HISTORY_(CAPTURE|ROLLUP|API)_ENABLED=[01]' /root/battlestats/server/.env
+```
+
+### Branch B1 — ROLLUP already = 1 (sweeper running nightly)
+
+Deploy the self-heal + reconciliation + index changes. **No initial backfill** — recent days are already built, and the first widened run reconciles the trailing window. Then flip `BATTLE_HISTORY_RECONCILE_ENABLED=1`, restart the workers, and verify with the check script.
+
+### Branch B2 — ROLLUP = 0 (calendrical layer dormant)
+
+This is an *enablement*, not just a patch — only the live 24h read window has data; the daily table is empty for history. Sequence:
+
+1. Deploy code + index migration with `BATTLE_HISTORY_ROLLUP_ENABLED` still **off** (additive, inert).
+2. **Initial backfill, strictly day-by-day**, via the existing management command from the capture-start date to yesterday:
+   ```bash
+   cd /root/battlestats/server
+   python manage.py rebuild_player_daily_ship_stats --since <capture-start> --until <yesterday>
+   ```
+   The command already loops one day at a time (`rebuild_player_daily_ship_stats.py:62-84`); each day is ~40K rows — safe. The OOM ceiling only bites a *single multi-day call* into the Python-load path, which the per-day loop avoids. **Never** attempt a multi-day rebuild in one call.
+3. Set `BATTLE_HISTORY_ROLLUP_ENABLED=1` (and `BATTLE_HISTORY_RECONCILE_ENABLED=1`), `systemctl restart battlestats-celery battlestats-celery-beat`.
+4. Verify via the check script and a clean reconciliation report.
+
+## Reconciliation interpretation
+
+- **Clean run:** one `logger.info` summary, zero discrepancies. The daily layer matches `BattleEvent` across the audit window.
+- **A discrepant date inside the trailing window (≤ N days):** the next nightly sweeper run will self-heal it; no action needed unless it persists across runs (which would indicate the sweeper is failing — check the `background` worker / Beat).
+- **A discrepant date beyond the window:** the self-heal will never reach it. Repair manually with `rebuild_player_daily_ship_stats --since <date> --until <date>` (day-by-day if a span). Re-run the check script to confirm it clears.
+- **Every recent date discrepant:** the rollup gate is off or the worker/Beat is down — this is exactly the "permanent holes" mode the reconcile task exists to surface. Fix the gate/worker, then backfill the gap day-by-day.
+
+## Rollback
+
+- **Self-heal:** set `BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS=1` to restore yesterday-only behavior without a redeploy (env read at runtime; restart workers).
+- **Reconciliation:** `BATTLE_HISTORY_RECONCILE_ENABLED=0` + restart — the task goes dormant. Alert-only, so it never touched data.
+- **Index:** reverse the `AddIndexConcurrently` migration (`DROP INDEX CONCURRENTLY`). No code references the index by name except the model `Meta`.
+- All three are independently reversible; none deletes data.
+
+## Validation
+
+1. **Local** (`[[project_local_dev_stack]]`): `BATTLE_HISTORY_ROLLUP_ENABLED=1`, seed `BattleEvent` across ~5 days, run the sweeper (lookback=3); inspect `PlayerDailyShipStats` coverage; run reconciliation → clean. Punch an in-window hole (delete one day's PDS) → sweeper heals it. Punch a beyond-window hole → reconciliation flags it; `rebuild_player_daily_ship_stats --since/--until` repairs it.
+2. **Migration:** apply locally; `EXPLAIN` the windowed range query to confirm the BRIN index is used.
+3. **Gate:** `python -m pytest server/warships/tests/test_incremental_battles.py -x` + the curated backend release gate.
+4. **Prod (post-deploy):** tail the `background` worker for the sweeper window summary + reconciliation WARNs; run `server/scripts/check_battle_history_rollup.sh`.
+
+### Test coverage (extend `server/warships/tests/test_incremental_battles.py`)
+
+Extend the existing suites (`RebuildDailyShipStatsTests` 1481, `RankedRollupWriteTests` 1565, `RebuildManagementCommandTests` 1738, `PeriodRollupsTests` 2892):
+
+- Sweeper rebuilds exactly the last N days; older days untouched.
+- Self-heal: delete PDS for an in-window day → task restores it; idempotent on re-run.
+- Period rebuild runs once per distinct period when the window crosses a week boundary.
+- Range filter preserves date isolation (existing canary tests pass after `__date`→range).
+- Reconciliation: detects BE-present/PDS-missing and under-counts; clean when consistent; ignores zero-battle days; respects the mode partition; performs no writes.
+- Reconcile task respects its own gate and is independent of the ROLLUP gate.
+
+## Known limitations
+
+- **Gap B — bucketing accuracy (structural, out of scope).** Because `detected_at` is the capture time, sparse `BattleObservation` capture collapses many real-play days onto one `detected_at`. The rollup faithfully mirrors *mis-bucketed* events; no amount of rollup recalculation fixes this. It is bounded by observation-floor density — see `runbook-battle-observation-floor-2026-05-02.md` and the floor-starvation note in `runbook-na-crawl-restart-loop-starves-refresh-2026-06-05.md`. This runbook guarantees the derived layer is *internally consistent with `BattleEvent`*, not that `BattleEvent` is bucketed on the true battle day.
+- **Phase 7 historical zeros (heals forward only).** The Phase 7 widening columns (gunnery/torpedo/spotting/caps deltas) are `0` for all pre-widening `BattleEvent` rows — the raw observations predate those keys. Rebuilding a historical day cannot recover them. See `runbook-battle-history-phase7-data-widening-2026-04-29.md`.
+- **Closed ship-badge seasons are frozen.** Ship-standings snapshots for closed seasons are not retroactively corrected by a rollup rebuild; `backfill_ship_seasons --wipe` only helps when the underlying events were dense in the first place.
+- **Reconciliation only alerts.** It never repairs. Beyond-window repair is always an explicit, human-initiated `rebuild_player_daily_ship_stats` run — deliberately, to avoid the unbounded multi-day Python-load OOM ceiling.
+
+## Out of scope (follow-ups)
+
+- **DB-side rewrite of `rebuild_daily_ship_stats_for_date`** — retires the `TODO(2026-Q3)` at `incremental_battles.py:982-985`; prerequisite for a *wide* lookback window (the current per-day Python load is only safe at small N).
+- **Gap B accuracy** — battle-time attribution / observation-floor density work.
+- **Reactivating the weekly/monthly/yearly period tiers in the UI** — they remain dormant; this work only keeps them internally consistent via the dedup'd rebuild.
+
+## Env knobs (full catalog in `ops-env-reference.md`)
+
+| Knob | Default | Effect |
+|---|---|---|
+| `BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS` | `3` | Trailing-window size the nightly sweeper rebuilds (self-heal). `1` = legacy yesterday-only. |
+| `BATTLE_HISTORY_RECONCILE_ENABLED` | `0` | Gates the alert-only reconciliation task; independent of `BATTLE_HISTORY_ROLLUP_ENABLED`. |
+| `BATTLE_HISTORY_RECONCILE_AUDIT_DAYS` | `30` | Audit window the reconciliation task scans. |
+
+## File map (implemented)
+
+| File | Change |
+|---|---|
+| `server/warships/tasks.py:1738` | Widen sweeper to trailing window + dedup period rebuild + global lock; add `reconcile_battle_history_rollup_task` |
+| `server/warships/incremental_battles.py:960,986,1039` | Half-open range filter; `rebuild_period_rollups_for_window`; `reconcile_daily_rollup_coverage` |
+| `server/warships/models.py:584` | `NOTE` documenting the BRIN index (built in the migration, not `Meta`) |
+| `server/warships/migrations/0063_battle_event_detected_brin.py` | Guarded `RunPython` `CREATE INDEX CONCURRENTLY ... USING brin` (`atomic=False`) |
+| `server/warships/signals.py:742` | Register `battle-history-rollup-reconcile` PeriodicTask |
+| `server/warships/management/commands/` | New `reconcile_battle_history_rollup`; range-filter `rebuild_player_daily_ship_stats.py:63` |
+| `server/scripts/check_battle_history_rollup.sh` | New read-only ops report (sibling of `check_enrichment_crawler.sh`) |
+| `agents/runbooks/ops-env-reference.md` | Three new knobs (done with this runbook) |
+
+## References
+
+- Rollout / Phase 3 sweeper origin: `agents/runbooks/runbook-battle-history-rollout-2026-04-28.md`.
+- Phase 7 widening (historical zeros): `agents/runbooks/runbook-battle-history-phase7-data-widening-2026-04-29.md`.
+- Observation floor (Gap B density): `agents/runbooks/runbook-battle-observation-floor-2026-05-02.md`.
+- Idempotent rebuild primitives: `server/warships/incremental_battles.py:960` (daily), `:1265,1356` (period).
+- Backfill/repair driver: `server/warships/management/commands/rebuild_player_daily_ship_stats.py`.
+- Lock + task-option conventions: `server/warships/tasks.py:170` (`_task_lock_key`), `:19` (`TASK_OPTS`), `:1797-1826` (lock usage).
+- Check-script conventions: `scripts/check_enrichment_crawler.sh`.

--- a/client/app/components/ClanDetail.tsx
+++ b/client/app/components/ClanDetail.tsx
@@ -95,6 +95,7 @@ const ClanDetail: React.FC<ClanDetailProps> = ({ clan, onBack, onSelectMember })
     }, [shareState]);
 
     const handleShare = async () => {
+        trackEvent('clan-share', { realm });
         try {
             const url = new URL(window.location.href);
             if (!url.searchParams.has('realm')) {
@@ -142,7 +143,7 @@ const ClanDetail: React.FC<ClanDetailProps> = ({ clan, onBack, onSelectMember })
                 <div className="inline-flex rounded-md border border-[var(--border)] text-xs font-medium">
                     <button
                         type="button"
-                        onClick={() => { if (chartMode !== '2d') { setChartMode('2d'); trackEvent('clan-chart-mode', { mode: '2d' }); } }}
+                        onClick={() => { if (chartMode !== '2d') { setChartMode('2d'); trackEvent('clan-chart-2d', { realm }); } }}
                         className={`px-3 py-1 rounded-l-md transition-colors ${chartMode === '2d'
                                 ? 'bg-[var(--accent-mid)] text-white'
                                 : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
@@ -152,7 +153,7 @@ const ClanDetail: React.FC<ClanDetailProps> = ({ clan, onBack, onSelectMember })
                     </button>
                     <button
                         type="button"
-                        onClick={() => { if (is3DAvailable && chartMode !== '3d') { setChartMode('3d'); trackEvent('clan-chart-mode', { mode: '3d' }); } }}
+                        onClick={() => { if (is3DAvailable && chartMode !== '3d') { setChartMode('3d'); trackEvent('clan-chart-3d', { realm }); } }}
                         disabled={!is3DAvailable}
                         title={!is3DAvailable ? 'KDR data not yet available' : 'View 3D scatter with KDR'}
                         className={`px-3 py-1 rounded-r-md transition-colors ${chartMode === '3d'

--- a/client/app/components/ClanSVG.tsx
+++ b/client/app/components/ClanSVG.tsx
@@ -629,8 +629,12 @@ const ClanSVGComponent: React.FC<ClanProps> = ({ clanId, onSelectMember, highlig
     }, [clanId]);
 
     const handleScaleSelect = useCallback((scale: 'linear' | 'log') => {
+        // Only an actual scale change is a meaningful toggle; re-clicking the
+        // active scale (which only re-pins the pref) stays out of the realtime feed.
+        if (effectiveScaleType !== scale) {
+            trackEvent(scale === 'log' ? 'clan-chart-log' : 'clan-chart-linear', { realm });
+        }
         setUserScalePref(scale);
-        trackEvent('chart-scale', { chart: 'clan-members', scale });
         if (typeof window === 'undefined') {
             return;
         }
@@ -639,7 +643,7 @@ const ClanSVGComponent: React.FC<ClanProps> = ({ clanId, onSelectMember, highlig
         } catch {
             // ignore storage failures (private mode / quota)
         }
-    }, [clanId]);
+    }, [clanId, effectiveScaleType, realm]);
 
     useEffect(() => {
         let cancelled = false;

--- a/client/app/components/RealmTopShipsTreemapSVG.tsx
+++ b/client/app/components/RealmTopShipsTreemapSVG.tsx
@@ -254,7 +254,7 @@ const RealmTopShipsTreemapSVG: React.FC = () => {
                             <button
                                 key={m}
                                 type="button"
-                                onClick={() => { if (mode !== m) { setMode(m); trackEvent('treemap-mode', { mode: m, realm }); } }}
+                                onClick={() => { if (mode !== m) { setMode(m); trackEvent(m === 'random' ? 'treemap-random' : 'treemap-ranked', { realm }); } }}
                                 aria-pressed={mode === m}
                                 className={`rounded px-2 py-0.5 transition-colors ${
                                     mode === m

--- a/client/app/components/__tests__/ClanDetail.test.tsx
+++ b/client/app/components/__tests__/ClanDetail.test.tsx
@@ -3,7 +3,9 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import ClanDetail from '../ClanDetail';
 
 const mockUseClanMembers = jest.fn();
+const mockUseClanMemberTiers = jest.fn();
 const mockClipboardWriteText = jest.fn();
+const trackEventMock = jest.fn();
 const onSelectMemberSpy = jest.fn();
 
 jest.mock('next/dynamic', () => {
@@ -44,12 +46,22 @@ jest.mock('../useClanMembers', () => ({
     useClanMembers: (...args: unknown[]) => mockUseClanMembers(...args),
 }));
 
+jest.mock('../useClanMemberTiers', () => ({
+    useClanMemberTiers: (...args: unknown[]) => mockUseClanMemberTiers(...args),
+}));
+
+jest.mock('../../lib/umami', () => ({
+    trackEvent: (...args: unknown[]) => trackEventMock(...args),
+}));
+
 describe('ClanDetail clan roster hydration wiring', () => {
     let consoleErrorSpy: jest.SpyInstance;
 
     beforeEach(() => {
         mockUseClanMembers.mockReturnValue({ members: [], loading: false, error: '' });
+        mockUseClanMemberTiers.mockReturnValue({ data: [], loading: false });
         mockClipboardWriteText.mockReset();
+        trackEventMock.mockReset();
         onSelectMemberSpy.mockReset();
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
@@ -198,5 +210,45 @@ describe('ClanDetail clan roster hydration wiring', () => {
 
         expect(await screen.findByText('Copy failed')).toBeInTheDocument();
         expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('fires a clan-share umami event when the share button is clicked', async () => {
+        mockClipboardWriteText.mockResolvedValue(undefined);
+
+        render(
+            <ClanDetail
+                clan={{ clan_id: 5555, name: 'Fixture Clan', tag: 'FX', members_count: 12 }}
+                onBack={() => undefined}
+                onSelectMember={() => undefined}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Copy shareable clan URL' }));
+
+        expect(trackEventMock).toHaveBeenCalledWith('clan-share', expect.objectContaining({ realm: expect.any(String) }));
+    });
+
+    it('fires name-encoded clan-chart-3d / clan-chart-2d events for the dimension toggle', () => {
+        // >=50% KDR coverage makes the 3D toggle available.
+        mockUseClanMemberTiers.mockReturnValue({
+            data: [{ kdr: 1.2 }, { kdr: 0.9 }],
+            loading: false,
+        });
+
+        render(
+            <ClanDetail
+                clan={{ clan_id: 5555, name: 'Fixture Clan', tag: 'FX', members_count: 12 }}
+                onBack={() => undefined}
+                onSelectMember={() => undefined}
+            />,
+        );
+
+        // Default is 2D, so switching to 3D fires clan-chart-3d (not clan-chart-2d).
+        fireEvent.click(screen.getByRole('button', { name: '3D' }));
+        expect(trackEventMock).toHaveBeenCalledWith('clan-chart-3d', expect.objectContaining({ realm: expect.any(String) }));
+
+        // Switching back fires clan-chart-2d — the two states are distinct event names.
+        fireEvent.click(screen.getByRole('button', { name: '2D' }));
+        expect(trackEventMock).toHaveBeenCalledWith('clan-chart-2d', expect.objectContaining({ realm: expect.any(String) }));
     });
 });

--- a/server/scripts/check_battle_history_rollup.sh
+++ b/server/scripts/check_battle_history_rollup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# check_battle_history_rollup.sh — One-shot battle-history rollup durability report
+# Usage: ./server/scripts/check_battle_history_rollup.sh [host] [audit_days]
+# Default host: battlestats.online, audit window: 30 days
+#
+# Read-only: runs the reconcile management command on the droplet and surfaces
+# the latest nightly rollup-task log summary. Never mutates.
+# Runbook: agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
+
+set -euo pipefail
+
+HOST="${1:-battlestats.online}"
+AUDIT_DAYS="${2:-30}"
+
+echo "========================================"
+echo "  Battle-History Rollup Durability Report"
+echo "  Host: $HOST"
+echo "  Audit window: ${AUDIT_DAYS} days"
+echo "  Time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo "========================================"
+
+ssh "root@${HOST}" AUDIT_DAYS="${AUDIT_DAYS}" bash -s <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+echo
+echo "## Rollup Gate State"
+echo
+
+ENV_FILE=/opt/battlestats-server/current/server/.env
+if [ -f "$ENV_FILE" ]; then
+    grep -hoE 'BATTLE_HISTORY_(ROLLUP|RECONCILE)[A-Z_]*=[^ ]*' "$ENV_FILE" \
+        | sed 's/^/  /' || echo "  (no BATTLE_HISTORY_ROLLUP/RECONCILE keys set — defaults apply)"
+else
+    echo "  (env file not found at $ENV_FILE)"
+fi
+
+echo
+echo "## Reconciliation (BattleEvent vs PlayerDailyShipStats)"
+echo
+
+cd /opt/battlestats-server/current/server
+source /opt/battlestats-server/venv/bin/activate
+set -a && source .env && source .env.secrets && set +a
+
+python manage.py reconcile_battle_history_rollup --audit-days "${AUDIT_DAYS}" 2>&1 \
+    | sed 's/^/  /'
+
+echo
+echo "## Last Nightly Rollup Run (24h journal)"
+echo
+
+ROLLUP_LOG=$(journalctl -u battlestats-celery-background --since '24 hours ago' --no-pager 2>/dev/null \
+    | grep -E 'roll_up_player_daily_ship_stats_task' | tail -4)
+if [ -z "$ROLLUP_LOG" ]; then
+    echo "  No rollup-task activity in the last 24h (sweeper disabled or idle?)"
+else
+    echo "$ROLLUP_LOG" | sed 's/^/  /'
+fi
+
+echo
+echo "## Reconcile Task WARNs (24h journal)"
+echo
+
+RECON_WARN=$(journalctl -u battlestats-celery-background --since '24 hours ago' --no-pager 2>/dev/null \
+    | grep -E 'battle-history rollup (hole|reconciliation)' | tail -6)
+if [ -z "$RECON_WARN" ]; then
+    echo "  No reconcile-task log lines in the last 24h (task disabled?)"
+else
+    echo "$RECON_WARN" | sed 's/^/  /'
+fi
+
+echo
+echo "========================================"
+echo "  Report complete"
+echo "========================================"
+REMOTE_SCRIPT

--- a/server/warships/incremental_battles.py
+++ b/server/warships/incremental_battles.py
@@ -957,6 +957,19 @@ def _invalidate_battle_history_cache(player) -> None:
     cache.delete_many(keys)
 
 
+def _utc_day_bounds(target_date) -> Tuple[datetime, datetime]:
+    """Half-open naive-UTC datetime bounds ``[day_start, next_day_start)``.
+
+    The project runs ``USE_TZ=False`` / UTC, so ``BattleEvent.detected_at`` is
+    a naive UTC datetime. Filtering with a half-open range predicate lets the
+    BRIN index on ``detected_at`` range-prune; a ``detected_at__date=`` lookup
+    wraps the column in a function and cannot use the index. See
+    ``agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md``.
+    """
+    day_start = datetime(target_date.year, target_date.month, target_date.day)
+    return day_start, day_start + timedelta(days=1)
+
+
 def rebuild_daily_ship_stats_for_date(target_date) -> Dict[str, Any]:
     """Rebuild `PlayerDailyShipStats` rows for `target_date` from BattleEvent.
 
@@ -968,6 +981,8 @@ def rebuild_daily_ship_stats_for_date(target_date) -> Dict[str, Any]:
     has explicitly asked for a rebuild.
     """
     from warships.models import BattleEvent, PlayerDailyShipStats
+
+    day_start, next_day_start = _utc_day_bounds(target_date)
 
     with transaction.atomic():
         deleted, _ = PlayerDailyShipStats.objects.filter(
@@ -984,7 +999,8 @@ def rebuild_daily_ship_stats_for_date(target_date) -> Dict[str, Any]:
         # values().annotate() group-by (Count(filter=survived) for survived,
         # grouped by player/ship/mode/season_id) like the period aggregator.
         events = BattleEvent.objects.filter(
-            detected_at__date=target_date,
+            detected_at__gte=day_start,
+            detected_at__lt=next_day_start,
         ).order_by("detected_at")
 
         rows: Dict[tuple, Dict[str, Any]] = {}
@@ -1037,7 +1053,8 @@ def rebuild_daily_ship_stats_for_date(target_date) -> Dict[str, Any]:
         "rows_deleted": deleted,
         "rows_written": len(rows),
         "events_seen": events.count() if rows else BattleEvent.objects.filter(
-            detected_at__date=target_date,
+            detected_at__gte=day_start,
+            detected_at__lt=next_day_start,
         ).count(),
     }
 
@@ -1254,12 +1271,30 @@ def _week_start(d) -> "date":
     return d - _td(days=d.weekday())
 
 
+def _week_end(week_start) -> "date":
+    from datetime import timedelta as _td
+    return week_start + _td(days=6)
+
+
 def _month_start(d) -> "date":
     return d.replace(day=1)
 
 
+def _month_end(month_start) -> "date":
+    from datetime import timedelta as _td
+    if month_start.month == 12:
+        next_month = month_start.replace(year=month_start.year + 1, month=1)
+    else:
+        next_month = month_start.replace(month=month_start.month + 1)
+    return next_month - _td(days=1)
+
+
 def _year_start(d) -> "date":
     return d.replace(month=1, day=1)
+
+
+def _year_end(year_start) -> "date":
+    return year_start.replace(month=12, day=31)
 
 
 def _aggregate_into_period_table(
@@ -1356,11 +1391,11 @@ def _aggregate_into_period_table(
 def rebuild_period_rollups_for_date(target_date) -> Dict[str, Any]:
     """Rebuild weekly + monthly + yearly rollup rows that cover `target_date`.
 
-    Called by the nightly sweeper after `rebuild_daily_ship_stats_for_date`,
-    so the period rollups always reflect the latest daily layer. Idempotent.
+    Called for single-date manual repair so the period rollups reflect the
+    latest daily layer. Idempotent. The nightly sweeper uses
+    `rebuild_period_rollups_for_window` instead, which dedups across the
+    trailing window so each period is rebuilt only once.
     """
-    from datetime import timedelta as _td
-
     from warships.models import (
         PlayerMonthlyShipStats,
         PlayerWeeklyShipStats,
@@ -1368,24 +1403,15 @@ def rebuild_period_rollups_for_date(target_date) -> Dict[str, Any]:
     )
 
     week_start = _week_start(target_date)
-    week_end = week_start + _td(days=6)
-
     month_start = _month_start(target_date)
-    if month_start.month == 12:
-        next_month = month_start.replace(year=month_start.year + 1, month=1)
-    else:
-        next_month = month_start.replace(month=month_start.month + 1)
-    month_end = next_month - _td(days=1)
-
     year_start = _year_start(target_date)
-    year_end = year_start.replace(month=12, day=31)
 
     weekly = _aggregate_into_period_table(
-        week_start, week_end, PlayerWeeklyShipStats)
+        week_start, _week_end(week_start), PlayerWeeklyShipStats)
     monthly = _aggregate_into_period_table(
-        month_start, month_end, PlayerMonthlyShipStats)
+        month_start, _month_end(month_start), PlayerMonthlyShipStats)
     yearly = _aggregate_into_period_table(
-        year_start, year_end, PlayerYearlyShipStats)
+        year_start, _year_end(year_start), PlayerYearlyShipStats)
 
     return {
         "status": "completed",
@@ -1394,6 +1420,113 @@ def rebuild_period_rollups_for_date(target_date) -> Dict[str, Any]:
         "monthly": monthly,
         "yearly": yearly,
     }
+
+
+def rebuild_period_rollups_for_window(dates) -> Dict[str, Any]:
+    """Rebuild weekly/monthly/yearly rollups covering every date in `dates`,
+    touching each distinct period exactly once.
+
+    The nightly sweeper rebuilds a trailing window of N days. A naive per-day
+    call to `rebuild_period_rollups_for_date` would re-aggregate the same
+    week/month/year up to N times (yearly is a full-YTD DB scan), so this
+    dedups to the distinct per-tier anchor set first, then aggregates each
+    anchor once. Idempotent. See
+    `agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md`.
+    """
+    from warships.models import (
+        PlayerMonthlyShipStats,
+        PlayerWeeklyShipStats,
+        PlayerYearlyShipStats,
+    )
+
+    week_anchors = sorted({_week_start(d) for d in dates})
+    month_anchors = sorted({_month_start(d) for d in dates})
+    year_anchors = sorted({_year_start(d) for d in dates})
+
+    weekly = [
+        _aggregate_into_period_table(a, _week_end(a), PlayerWeeklyShipStats)
+        for a in week_anchors
+    ]
+    monthly = [
+        _aggregate_into_period_table(a, _month_end(a), PlayerMonthlyShipStats)
+        for a in month_anchors
+    ]
+    yearly = [
+        _aggregate_into_period_table(a, _year_end(a), PlayerYearlyShipStats)
+        for a in year_anchors
+    ]
+
+    return {
+        "status": "completed",
+        "weeks_rebuilt": len(week_anchors),
+        "months_rebuilt": len(month_anchors),
+        "years_rebuilt": len(year_anchors),
+        "weekly": weekly,
+        "monthly": monthly,
+        "yearly": yearly,
+    }
+
+
+def reconcile_daily_rollup_coverage(audit_days: int = 30) -> Dict[str, Any]:
+    """Alert-only audit: compare BattleEvent vs PlayerDailyShipStats coverage.
+
+    Per `(date, mode)` over the trailing `audit_days` window (excluding today,
+    which is still mid-capture), compares `SUM(BattleEvent.battles_delta)`
+    against `SUM(PlayerDailyShipStats.battles)`. Both sides are DB-side
+    aggregates — no Python row load. Flags any date where BattleEvent has
+    battles the daily layer is missing or under-counts; legitimately-zero days
+    are ignored. Compares per mode because the daily layer carries random +
+    ranked while the period tiers are randoms-only — so we reconcile the daily
+    layer, never the period tiers.
+
+    Returns the discrepancy list; writes nothing. Repair beyond the self-heal
+    window is the human-run `rebuild_player_daily_ship_stats` command. See
+    `agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md`.
+    """
+    from django.db.models import Sum
+    from django.db.models.functions import TruncDate
+
+    from warships.models import BattleEvent, PlayerDailyShipStats
+
+    today = datetime.now(timezone.utc).date()
+    window_start = today - timedelta(days=audit_days)
+    start_dt = datetime(window_start.year, window_start.month, window_start.day)
+    end_dt = datetime(today.year, today.month, today.day)
+
+    be_rows = (
+        BattleEvent.objects
+        .filter(detected_at__gte=start_dt, detected_at__lt=end_dt)
+        .annotate(d=TruncDate("detected_at"))
+        .values("d", "mode")
+        .annotate(be_battles=Sum("battles_delta"))
+        .order_by()
+    )
+    be_map = {(r["d"], r["mode"]): (r["be_battles"] or 0) for r in be_rows}
+
+    pds_rows = (
+        PlayerDailyShipStats.objects
+        .filter(date__gte=window_start, date__lt=today)
+        .values("date", "mode")
+        .annotate(pds_battles=Sum("battles"))
+        .order_by()
+    )
+    pds_map = {(r["date"], r["mode"]): (r["pds_battles"] or 0) for r in pds_rows}
+
+    discrepancies: List[Dict[str, Any]] = []
+    for (d, mode), be_battles in sorted(be_map.items()):
+        if be_battles <= 0:
+            continue  # ignore legitimately-zero days
+        pds_battles = pds_map.get((d, mode), 0)
+        if pds_battles < be_battles:
+            discrepancies.append({
+                "date": str(d),
+                "mode": mode,
+                "be_battles": be_battles,
+                "pds_battles": pds_battles,
+                "delta": be_battles - pds_battles,
+            })
+
+    return {"discrepancies": discrepancies, "audit_days": audit_days}
 
 
 def record_observation_and_diff(player_id: int, realm: str) -> Dict[str, Any]:

--- a/server/warships/management/commands/rebuild_player_daily_ship_stats.py
+++ b/server/warships/management/commands/rebuild_player_daily_ship_stats.py
@@ -37,7 +37,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        from warships.incremental_battles import rebuild_daily_ship_stats_for_date
+        from warships.incremental_battles import (
+            _utc_day_bounds,
+            rebuild_daily_ship_stats_for_date,
+        )
         from warships.models import BattleEvent, PlayerDailyShipStats
 
         try:
@@ -60,8 +63,10 @@ class Command(BaseCommand):
         total_events = 0
         total_rows_written = 0
         while cursor <= until:
+            day_start, next_day_start = _utc_day_bounds(cursor)
             event_count = BattleEvent.objects.filter(
-                detected_at__date=cursor,
+                detected_at__gte=day_start,
+                detected_at__lt=next_day_start,
             ).count()
             existing_rows = PlayerDailyShipStats.objects.filter(
                 date=cursor,

--- a/server/warships/management/commands/reconcile_battle_history_rollup.py
+++ b/server/warships/management/commands/reconcile_battle_history_rollup.py
@@ -1,0 +1,49 @@
+"""Report battle-history daily rollup coverage gaps (alert-only, read-only).
+
+Compares BattleEvent vs PlayerDailyShipStats battle counts per (date, mode)
+over an audit window and prints any date the daily layer is missing or
+under-counts. Writes nothing — repair is the `rebuild_player_daily_ship_stats`
+command (day-by-day for a span).
+
+See agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md.
+
+Examples:
+    python manage.py reconcile_battle_history_rollup
+    python manage.py reconcile_battle_history_rollup --audit-days 60
+"""
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Report PlayerDailyShipStats coverage gaps vs BattleEvent (read-only)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--audit-days", type=int, default=30,
+            help="Number of trailing days to audit (default 30).",
+        )
+
+    def handle(self, *args, **options):
+        from warships.incremental_battles import reconcile_daily_rollup_coverage
+
+        audit_days = max(1, options["audit_days"])
+        report = reconcile_daily_rollup_coverage(audit_days=audit_days)
+        discrepancies = report["discrepancies"]
+
+        if not discrepancies:
+            self.stdout.write(self.style.SUCCESS(
+                f"Clean: no rollup gaps over the last {audit_days} days."))
+            return
+
+        self.stdout.write(self.style.WARNING(
+            f"Found {len(discrepancies)} rollup gap(s) over {audit_days} days:"))
+        for d in discrepancies:
+            self.stdout.write(self.style.WARNING(
+                f"  {d['date']} {d['mode']}: "
+                f"be_battles={d['be_battles']} pds_battles={d['pds_battles']} "
+                f"delta={d['delta']}"))
+        self.stdout.write(
+            "Repair with: python manage.py rebuild_player_daily_ship_stats "
+            "--since <date> --until <date>")

--- a/server/warships/migrations/0063_battle_event_detected_brin.py
+++ b/server/warships/migrations/0063_battle_event_detected_brin.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+
+
+def create_brin_index(apps, schema_editor):
+    # Postgres-only; the release gate / local subsets build the SQLite test DB
+    # with `--nomigrations` and SQLite has no BRIN. Mirror the guarded pattern
+    # in 0019 (pg_trgm GIN index) — the index lives in this migration, not in
+    # BattleEvent.Meta, so the syncdb test-DB build never emits `USING brin`.
+    #
+    # CONCURRENTLY (with atomic=False below) avoids a disruptive lock on the
+    # large, high-write BattleEvent table. detected_at is monotonic, so a BRIN
+    # index range-prunes the per-day rollup + reconciliation scans cheaply.
+    if schema_editor.connection.vendor != 'postgresql':
+        return
+    schema_editor.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS battle_event_detected_brin "
+        "ON warships_battleevent USING brin (detected_at)"
+    )
+
+
+def drop_brin_index(apps, schema_editor):
+    if schema_editor.connection.vendor != 'postgresql':
+        return
+    schema_editor.execute(
+        "DROP INDEX CONCURRENTLY IF EXISTS battle_event_detected_brin"
+    )
+
+
+class Migration(migrations.Migration):
+    # CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("warships", "0062_shipaward"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_brin_index, reverse_code=drop_brin_index),
+    ]

--- a/server/warships/models.py
+++ b/server/warships/models.py
@@ -585,6 +585,14 @@ class BattleEvent(models.Model):
             models.Index(fields=['player', '-detected_at'],
                          name='battle_event_player_time_idx'),
         ]
+        # NOTE: a Postgres BRIN index on `detected_at` (monotonic insert-time
+        # NOW()) range-prunes the per-day rollup + reconciliation scans at
+        # negligible write cost. It is added via the guarded raw-SQL migration
+        # 0063 (CREATE INDEX CONCURRENTLY ... USING brin) rather than declared
+        # here, mirroring the pg_trgm GIN index pattern (migration 0019): the
+        # release gate builds the SQLite test DB straight from this Meta with
+        # `--nomigrations`, and SQLite has no BRIN. See
+        # runbook-battle-history-rollup-durability-2026-06-06.md.
 
     def __str__(self):
         return (

--- a/server/warships/signals.py
+++ b/server/warships/signals.py
@@ -761,6 +761,34 @@ def register_periodic_schedules(sender, **kwargs):
             "enabled": True,
             "args": json.dumps([]),
             "kwargs": json.dumps({}),
-            "description": "Nightly rebuild of PlayerDailyShipStats from BattleEvent. No-op unless BATTLE_HISTORY_ROLLUP_ENABLED=1.",
+            "description": "Nightly rebuild of PlayerDailyShipStats from BattleEvent (self-healing trailing window). No-op unless BATTLE_HISTORY_ROLLUP_ENABLED=1.",
+        },
+    )
+
+    # -- Battle History Rollup reconciliation (alert-only) --
+    # Runbook: agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
+    # Gate-independent of BATTLE_HISTORY_ROLLUP_ENABLED so it can surface holes
+    # even when the rollup gate is off. No-op unless
+    # BATTLE_HISTORY_RECONCILE_ENABLED=1. Fires after the rollup window (04:30)
+    # completes.
+    reconcile_hour = os.getenv("BATTLE_HISTORY_RECONCILE_HOUR", "5")
+    reconcile_minute = os.getenv("BATTLE_HISTORY_RECONCILE_MINUTE", "0")
+    battle_history_reconcile_schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute=str(reconcile_minute),
+        hour=str(reconcile_hour),
+        day_of_week="*",
+        day_of_month="*",
+        month_of_year="*",
+        timezone="UTC",
+    )
+    PeriodicTask.objects.update_or_create(
+        name="battle-history-rollup-reconcile",
+        defaults={
+            "task": "warships.tasks.reconcile_battle_history_rollup_task",
+            "crontab": battle_history_reconcile_schedule,
+            "enabled": True,
+            "args": json.dumps([]),
+            "kwargs": json.dumps({}),
+            "description": "Alert-only reconciliation of PlayerDailyShipStats vs BattleEvent. No-op unless BATTLE_HISTORY_RECONCILE_ENABLED=1.",
         },
     )

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -1735,13 +1735,21 @@ def dispatch_tracked_player_polls_task():
     return {"status": "completed", "dispatched": dispatched, "tracked": len(players)}
 
 
-@app.task(queue='background', **TASK_OPTS)
-def roll_up_player_daily_ship_stats_task(target_date_iso=None):
-    """Nightly sweeper: rebuild PlayerDailyShipStats for the previous calendar
-    day from BattleEvent rows. No-op when BATTLE_HISTORY_ROLLUP_ENABLED!=1.
+@app.task(bind=True, queue='background', **TASK_OPTS)
+def roll_up_player_daily_ship_stats_task(self, target_date_iso=None):
+    """Nightly sweeper: rebuild PlayerDailyShipStats from BattleEvent rows.
 
-    Phase 3 of the battle-history rollout. Idempotent — re-running produces
-    identical row counts and values for the same target date.
+    Self-healing trailing window — rebuilds the last
+    BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS calendar days (default 3), not just
+    yesterday, so a short outage (disabled gate / down worker / Beat misfire)
+    no longer leaves a permanent hole: each nightly run re-closes the trailing
+    window. Idempotent delete+rebuild makes re-running an already-correct day
+    a no-op-equivalent. No-op when BATTLE_HISTORY_ROLLUP_ENABLED != 1.
+
+    A single explicit `target_date_iso` collapses the window to that one day
+    (manual single-date repair), matching the legacy behaviour.
+
+    See agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md.
     """
     if os.getenv("BATTLE_HISTORY_ROLLUP_ENABLED", "0") != "1":
         return {"status": "skipped", "reason": "rollup-disabled"}
@@ -1750,30 +1758,97 @@ def roll_up_player_daily_ship_stats_task(target_date_iso=None):
 
     from warships.incremental_battles import (
         rebuild_daily_ship_stats_for_date,
-        rebuild_period_rollups_for_date,
+        rebuild_period_rollups_for_window,
     )
 
     if target_date_iso:
-        target_date = datetime.strptime(target_date_iso, "%Y-%m-%d").date()
+        last_date = datetime.strptime(target_date_iso, "%Y-%m-%d").date()
+        lookback = 1
     else:
-        target_date = (
+        last_date = (
             datetime.now(dt_timezone.utc) - timedelta(days=1)
         ).date()
+        lookback = max(
+            1, int(os.getenv("BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS", "3")))
 
-    logger.info(
-        "Starting roll_up_player_daily_ship_stats_task for date=%s", target_date)
-    daily_result = rebuild_daily_ship_stats_for_date(target_date)
-    # Cascade into the weekly / monthly / yearly tiers covering the same
-    # date, so coarser views always reflect the latest daily layer.
-    period_result = rebuild_period_rollups_for_date(target_date)
-    logger.info(
-        "Finished roll_up_player_daily_ship_stats_task: daily=%s period=%s",
-        daily_result, period_result)
-    return {
-        "status": "completed",
-        "daily": daily_result,
-        "period": period_result,
-    }
+    # Oldest -> yesterday, so logs and period dedup read in calendar order.
+    dates = [
+        last_date - timedelta(days=offset)
+        for offset in range(lookback - 1, -1, -1)
+    ]
+
+    # Single-run global lock — the windowed run outlasts a single day and
+    # could overlap a slow prior run. Lock auto-expires if the worker dies.
+    lock_key = _task_lock_key("roll_up_player_daily_ship_stats", "global")
+    if not cache.add(lock_key, self.request.id,
+                     timeout=RESOURCE_TASK_LOCK_TIMEOUT):
+        logger.info(
+            "Skipping roll_up_player_daily_ship_stats_task — another run is active")
+        return {"status": "skipped", "reason": "already-running"}
+
+    try:
+        logger.info(
+            "Starting roll_up_player_daily_ship_stats_task window=%s..%s (%d days)",
+            dates[0], dates[-1], len(dates))
+        daily_results = [rebuild_daily_ship_stats_for_date(d) for d in dates]
+        # Cascade into the weekly / monthly / yearly tiers covering the window,
+        # each distinct period rebuilt once, so coarser views always reflect
+        # the latest daily layer.
+        period_result = rebuild_period_rollups_for_window(dates)
+        logger.info(
+            "Finished roll_up_player_daily_ship_stats_task: days_rebuilt=%d "
+            "periods_rebuilt=w%d/m%d/y%d",
+            len(daily_results),
+            period_result["weeks_rebuilt"],
+            period_result["months_rebuilt"],
+            period_result["years_rebuilt"])
+        return {
+            "status": "completed",
+            "days_rebuilt": len(daily_results),
+            "daily": daily_results,
+            "period": period_result,
+        }
+    finally:
+        cache.delete(lock_key)
+
+
+@app.task(queue='background', **TASK_OPTS)
+def reconcile_battle_history_rollup_task():
+    """Alert-only reconciliation of the battle-history daily rollup.
+
+    Compares SUM(BattleEvent.battles_delta) vs SUM(PlayerDailyShipStats.battles)
+    per (date, mode) over an audit window and logs any date where BattleEvent
+    has battles the daily layer is missing or under-counts. Writes nothing —
+    repair beyond the self-heal window is the human-run
+    `rebuild_player_daily_ship_stats` command.
+
+    Gated by BATTLE_HISTORY_RECONCILE_ENABLED (default 0), INDEPENDENT of
+    BATTLE_HISTORY_ROLLUP_ENABLED so it can surface "rollup is off / holes
+    exist" even when the rollup gate is down. Audit window from
+    BATTLE_HISTORY_RECONCILE_AUDIT_DAYS (default 30). See
+    agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md.
+    """
+    if os.getenv("BATTLE_HISTORY_RECONCILE_ENABLED", "0") != "1":
+        return {"status": "skipped", "reason": "reconcile-disabled"}
+
+    from warships.incremental_battles import reconcile_daily_rollup_coverage
+
+    audit_days = max(
+        1, int(os.getenv("BATTLE_HISTORY_RECONCILE_AUDIT_DAYS", "30")))
+    report = reconcile_daily_rollup_coverage(audit_days=audit_days)
+    discrepancies = report["discrepancies"]
+    if discrepancies:
+        for d in discrepancies:
+            logger.warning(
+                "battle-history rollup hole: date=%s mode=%s be_battles=%d "
+                "pds_battles=%d delta=%d",
+                d["date"], d["mode"], d["be_battles"], d["pds_battles"],
+                d["delta"])
+    else:
+        logger.info(
+            "battle-history rollup reconciliation clean over %d days",
+            audit_days)
+    return {"status": "completed", **report}
 
 
 @app.task(bind=True, queue='background', **TASK_OPTS)

--- a/server/warships/tests/test_incremental_battles.py
+++ b/server/warships/tests/test_incremental_battles.py
@@ -34,6 +34,8 @@ from warships.incremental_battles import (
     compute_ranked_battle_events,
     rebuild_daily_ship_stats_for_date,
     rebuild_period_rollups_for_date,
+    rebuild_period_rollups_for_window,
+    reconcile_daily_rollup_coverage,
     record_observation_and_diff,
     record_observation_from_payloads,
     record_ranked_observation_and_diff,
@@ -3511,3 +3513,237 @@ class CompactBattleObservationPayloadsTests(TestCase):
             keep_per_player=1, batch_size=1)
         self.assertEqual(result["cleared"], 4)
         self.assertGreaterEqual(result["batches"], 4)
+
+
+class RollupDurabilityTests(TestCase):
+    """Self-healing trailing window + dedup'd period rebuild for the sweeper.
+
+    Runbook: agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
+    """
+
+    def setUp(self):
+        self.player = Player.objects.create(
+            name="durability_test", player_id=77777, realm="na",
+            pvp_battles=100,
+        )
+        Ship.objects.create(
+            ship_id=42, name="Yamato", nation="japan",
+            ship_type="Battleship", tier=10,
+        )
+        self.today = django_timezone.now().date()
+        self.yesterday = self.today - timedelta(days=1)
+
+    def _event_on(self, target_date, *, battles=1, mode="random",
+                  season_id=None, survived=True):
+        a = BattleObservation.objects.create(player=self.player, pvp_battles=0)
+        b = BattleObservation.objects.create(player=self.player, pvp_battles=0)
+        ev = BattleEvent.objects.create(
+            player=self.player, ship_id=42, ship_name="Yamato",
+            battles_delta=battles, wins_delta=battles, frags_delta=1,
+            damage_delta=10_000, xp_delta=500, survived=survived,
+            mode=mode, season_id=season_id,
+            from_observation=a, to_observation=b,
+        )
+        # detected_at is auto_now_add; override to land the event on the
+        # intended capture day (naive UTC — USE_TZ=False project).
+        noon = datetime(target_date.year, target_date.month, target_date.day, 12)
+        BattleEvent.objects.filter(pk=ev.pk).update(detected_at=noon)
+        return ev
+
+    def _run_sweeper(self, lookback=3, target_date_iso=None):
+        from warships.tasks import roll_up_player_daily_ship_stats_task
+        with mock.patch.dict("os.environ", {
+            "BATTLE_HISTORY_ROLLUP_ENABLED": "1",
+            "BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS": str(lookback),
+        }):
+            kwargs = {"target_date_iso": target_date_iso} if target_date_iso else {}
+            return roll_up_player_daily_ship_stats_task.apply(kwargs=kwargs).get()
+
+    def test_sweeper_rebuilds_exactly_last_n_days(self):
+        for d in range(0, 4):  # yesterday, -1, -2, -3
+            self._event_on(self.yesterday - timedelta(days=d), battles=1)
+        result = self._run_sweeper(lookback=3)
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["days_rebuilt"], 3)
+        built = set(PlayerDailyShipStats.objects.values_list("date", flat=True))
+        for d in range(0, 3):
+            self.assertIn(self.yesterday - timedelta(days=d), built)
+        # The 4th-oldest day is outside the lookback window — not built.
+        self.assertNotIn(self.yesterday - timedelta(days=3), built)
+
+    def test_sweeper_does_not_touch_days_outside_window(self):
+        canary = PlayerDailyShipStats.objects.create(
+            player=self.player, date=self.yesterday - timedelta(days=40),
+            ship_id=42, ship_name="Yamato", battles=99, wins=99, frags=99,
+        )
+        self._event_on(self.yesterday, battles=1)
+        self._run_sweeper(lookback=3)
+        canary.refresh_from_db()
+        self.assertEqual(canary.battles, 99)
+
+    def test_self_heal_restores_in_window_hole(self):
+        self._event_on(self.yesterday, battles=2)
+        self._run_sweeper(lookback=3)
+        # Simulate an outage that left a hole on a day now inside the window.
+        PlayerDailyShipStats.objects.filter(date=self.yesterday).delete()
+        self.assertFalse(
+            PlayerDailyShipStats.objects.filter(date=self.yesterday).exists())
+        # The next nightly run re-closes the trailing window.
+        self._run_sweeper(lookback=3)
+        row = PlayerDailyShipStats.objects.get(date=self.yesterday)
+        self.assertEqual(row.battles, 2)
+
+    def test_sweeper_idempotent_on_rerun(self):
+        self._event_on(self.yesterday, battles=2)
+        self._run_sweeper(lookback=3)
+        first = PlayerDailyShipStats.objects.count()
+        self._run_sweeper(lookback=3)
+        self.assertEqual(PlayerDailyShipStats.objects.count(), first)
+
+    def test_explicit_target_date_collapses_window_to_one_day(self):
+        self._event_on(self.yesterday, battles=1)
+        self._event_on(self.yesterday - timedelta(days=1), battles=1)
+        # Even with a wide lookback env, an explicit date rebuilds only that day.
+        result = self._run_sweeper(
+            lookback=7, target_date_iso=self.yesterday.isoformat())
+        self.assertEqual(result["days_rebuilt"], 1)
+        built = set(PlayerDailyShipStats.objects.values_list("date", flat=True))
+        self.assertEqual(built, {self.yesterday})
+
+    def test_sweeper_skipped_when_gate_off(self):
+        from warships.tasks import roll_up_player_daily_ship_stats_task
+        with mock.patch.dict(
+            "os.environ", {"BATTLE_HISTORY_ROLLUP_ENABLED": "0"},
+        ):
+            result = roll_up_player_daily_ship_stats_task.apply().get()
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["reason"], "rollup-disabled")
+
+    def test_period_window_dedups_distinct_anchors(self):
+        from warships.incremental_battles import _week_start
+        # A Monday and the prior Sunday fall in two distinct ISO weeks.
+        monday = self.today - timedelta(days=self.today.weekday())
+        sunday = monday - timedelta(days=1)
+        for d in (sunday, monday):
+            PlayerDailyShipStats.objects.create(
+                player=self.player, date=d, ship_id=42, ship_name="Yamato",
+                battles=1, wins=1, frags=1, mode="random",
+            )
+        # Duplicate `monday` in the input asserts the dedup collapses it.
+        result = rebuild_period_rollups_for_window([sunday, monday, monday])
+        self.assertEqual(result["weeks_rebuilt"], 2)
+        self.assertTrue(PlayerWeeklyShipStats.objects.filter(
+            period_start=_week_start(sunday)).exists())
+        self.assertTrue(PlayerWeeklyShipStats.objects.filter(
+            period_start=monday).exists())
+
+
+class RollupReconciliationTests(TestCase):
+    """Alert-only reconciliation of PlayerDailyShipStats vs BattleEvent.
+
+    Runbook: agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
+    """
+
+    def setUp(self):
+        self.player = Player.objects.create(
+            name="recon_test", player_id=88888, realm="na", pvp_battles=100,
+        )
+        Ship.objects.create(
+            ship_id=42, name="Yamato", nation="japan",
+            ship_type="Battleship", tier=10,
+        )
+        self.today = django_timezone.now().date()
+        self.day = self.today - timedelta(days=2)
+
+    def _event_on(self, target_date, *, battles=1, mode="random",
+                  season_id=None):
+        a = BattleObservation.objects.create(player=self.player, pvp_battles=0)
+        b = BattleObservation.objects.create(player=self.player, pvp_battles=0)
+        ev = BattleEvent.objects.create(
+            player=self.player, ship_id=42, ship_name="Yamato",
+            battles_delta=battles, wins_delta=battles, frags_delta=1,
+            damage_delta=10_000, xp_delta=500, survived=True,
+            mode=mode, season_id=season_id,
+            from_observation=a, to_observation=b,
+        )
+        noon = datetime(target_date.year, target_date.month, target_date.day, 12)
+        BattleEvent.objects.filter(pk=ev.pk).update(detected_at=noon)
+        return ev
+
+    def _pds(self, target_date, *, battles, mode="random", season_id=None):
+        return PlayerDailyShipStats.objects.create(
+            player=self.player, date=target_date, ship_id=42,
+            ship_name="Yamato", battles=battles, wins=battles, frags=1,
+            mode=mode, season_id=season_id,
+        )
+
+    def test_detects_missing_pds(self):
+        self._event_on(self.day, battles=3)
+        report = reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(len(report["discrepancies"]), 1)
+        d = report["discrepancies"][0]
+        self.assertEqual(d["date"], str(self.day))
+        self.assertEqual(d["mode"], "random")
+        self.assertEqual(d["be_battles"], 3)
+        self.assertEqual(d["pds_battles"], 0)
+        self.assertEqual(d["delta"], 3)
+
+    def test_detects_undercount(self):
+        self._event_on(self.day, battles=5)
+        self._pds(self.day, battles=2)
+        report = reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(len(report["discrepancies"]), 1)
+        self.assertEqual(report["discrepancies"][0]["delta"], 3)
+
+    def test_clean_when_consistent(self):
+        self._event_on(self.day, battles=4)
+        self._pds(self.day, battles=4)
+        report = reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(report["discrepancies"], [])
+
+    def test_ignores_zero_battle_days(self):
+        self._event_on(self.day, battles=0)
+        report = reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(report["discrepancies"], [])
+
+    def test_mode_partitioned(self):
+        # Random reconciles fine; ranked has a hole on the same day.
+        self._event_on(self.day, battles=2, mode="random")
+        self._pds(self.day, battles=2, mode="random")
+        self._event_on(self.day, battles=3, mode="ranked", season_id=10)
+        report = reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(len(report["discrepancies"]), 1)
+        self.assertEqual(report["discrepancies"][0]["mode"], "ranked")
+        self.assertEqual(report["discrepancies"][0]["delta"], 3)
+
+    def test_performs_no_writes(self):
+        self._event_on(self.day, battles=3)
+        before = PlayerDailyShipStats.objects.count()
+        reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(PlayerDailyShipStats.objects.count(), before)
+
+    def test_excludes_today(self):
+        # An event captured today is mid-window and must not be flagged.
+        self._event_on(self.today, battles=3)
+        report = reconcile_daily_rollup_coverage(audit_days=30)
+        self.assertEqual(report["discrepancies"], [])
+
+    def test_task_runs_independent_of_rollup_gate(self):
+        from warships.tasks import reconcile_battle_history_rollup_task
+        self._event_on(self.day, battles=3)
+        # RECONCILE on, ROLLUP off — the task must still detect the hole.
+        with mock.patch.dict("os.environ", {
+            "BATTLE_HISTORY_RECONCILE_ENABLED": "1",
+            "BATTLE_HISTORY_ROLLUP_ENABLED": "0",
+        }):
+            result = reconcile_battle_history_rollup_task.apply().get()
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(len(result["discrepancies"]), 1)
+
+    def test_task_skipped_when_reconcile_gate_off(self):
+        from warships.tasks import reconcile_battle_history_rollup_task
+        with mock.patch.dict(
+            "os.environ", {"BATTLE_HISTORY_RECONCILE_ENABLED": "0"},
+        ):
+            result = reconcile_battle_history_rollup_task.apply().get()
+        self.assertEqual(result["status"], "skipped")


### PR DESCRIPTION
## Summary

Captures the requested clan-page interactions in Umami and disambiguates the chart toggles so each control reads as a distinct, self-describing row in the **realtime** feed — value baked into the event name rather than hidden in an event-data property. Also aligns the landing treemap toggle to the same convention for consistency. Analytics-only; no API/contract changes.

### Clan page (`ClanDetail` / `ClanSVG`)

| Control | Now fires | Was |
|---|---|---|
| 2D / 3D dimension toggle | `clan-chart-2d` / `clan-chart-3d` | `clan-chart-mode { mode }` |
| log / linear x-axis scale | `clan-chart-log` / `clan-chart-linear` | `chart-scale { scale }` |
| Share button | `clan-share` | *(untracked)* |

### Landing page (`RealmTopShipsTreemapSVG`)

| Control | Now fires | Was |
|---|---|---|
| Random / Ranked battle-mode toggle | `treemap-random` / `treemap-ranked` | `treemap-mode { mode }` |

All events carry `{ realm }` for low-cardinality breakdowns. The scale toggle only fires on an actual scale change (`effectiveScaleType` guard) so re-pinning the already-active scale stays out of the feed; the dimension toggle keeps its existing already-active guard.

## Test coverage

- `ClanDetail.test.tsx`: asserts `clan-share` and the `clan-chart-2d` / `clan-chart-3d` pair (8 pass).
- `clan-chart-log`/`clan-chart-linear` (incl. the `effectiveScaleType` change-guard) and the treemap rename are **not** unit-tested — ClanSVG's and the treemap's tests are retired/absent (d3 ESM), same precedent as the other d3 chart components. Verified by inspection.

## Verification

- `tsc` + ESLint clean on all touched files; `npm run build` succeeds.
- Grep confirms no doc/test referenced the old `chart-scale` / `clan-chart-mode` / `treemap-mode` names.

## Note for the Umami instance

The renames orphan any saved Umami report/widget keyed on the old event names (`chart-scale`, `clan-chart-mode`, `treemap-mode`) — those views will silently stop populating and should be re-pointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)