### PR TITLE
feat(analytics): player-page share, history-window, and insights-tab events

### DIFF
--- a/client/app/components/BattleHistoryCard.tsx
+++ b/client/app/components/BattleHistoryCard.tsx
@@ -829,6 +829,9 @@ const BattleHistoryCard: React.FC<BattleHistoryCardProps> = ({
                                     type="button"
                                     onClick={() => {
                                         if (dayDisabled) return;
+                                        if (!isActive) {
+                                            trackEvent(`player-history-${w}`, { realm });
+                                        }
                                         setWindow(w);
                                         setUserPickedWindow(true);
                                     }}

--- a/client/app/components/PlayerDetail.tsx
+++ b/client/app/components/PlayerDetail.tsx
@@ -24,6 +24,7 @@ import type { PlayerClanBattleSummary } from './PlayerClanBattleSeasons';
 import { dispatchPlayerRouteSectionRendered, usePlayerRouteDiagnostics } from './usePlayerRouteDiagnostics';
 import { useTheme } from '../context/ThemeContext';
 import { useRealm } from '../context/RealmContext';
+import { trackEvent } from '../lib/umami';
 import wrColor from '../lib/wrColor';
 
 interface PlayerDetailProps {
@@ -336,6 +337,7 @@ const PlayerDetail: React.FC<PlayerDetailProps> = ({
     }, [player.clan_id, player.is_hidden, player.player_id]);
 
     const handleShare = async () => {
+        trackEvent('player-share', { realm });
         try {
             const url = new URL(window.location.href);
             if (!url.searchParams.has('realm')) {

--- a/client/app/components/PlayerDetailInsightsTabs.tsx
+++ b/client/app/components/PlayerDetailInsightsTabs.tsx
@@ -121,6 +121,17 @@ const panelSectionIdByTab: Record<InsightsTabId, string> = {
     career: 'insights-career',
 };
 
+// Umami event name per tab — value baked into the name (readable label, not the
+// internal id) so each tab reads as a distinct row in the realtime feed.
+const insightsTabEventByTab: Record<InsightsTabId, string> = {
+    ships: 'player-insights-ships',
+    profile: 'player-insights-profile',
+    ranked: 'player-insights-ranked',
+    career: 'player-insights-clan-battles',
+    badges: 'player-insights-efficiency',
+    population: 'player-insights-population',
+};
+
 const TAB_DATA_WARMUP_DELAY_MS = 250;
 const TAB_DATA_WARMUP_IDLE_TIMEOUT_MS = 1500;
 const PROFILE_FETCH_RETRY_DELAY_MS = 350;
@@ -349,8 +360,10 @@ const PlayerDetailInsightsTabs: React.FC<PlayerDetailInsightsTabsProps> = ({
                                 aria-controls={`player-insights-panel-${tab.id}`}
                                 tabIndex={isActive ? 0 : -1}
                                 onClick={() => {
+                                    if (tab.id !== activeTab) {
+                                        trackEvent(insightsTabEventByTab[tab.id], { realm });
+                                    }
                                     setActiveTab(tab.id);
-                                    trackEvent('insights-tab', { tab: tab.id });
                                 }}
                                 className={isActive
                                     ? 'rounded-full border border-[var(--accent-mid)] bg-[var(--accent-faint)] px-3 py-1.5 text-sm font-medium text-[var(--accent-mid)]'

--- a/client/app/components/__tests__/BattleHistoryCard.test.tsx
+++ b/client/app/components/__tests__/BattleHistoryCard.test.tsx
@@ -15,6 +15,11 @@ jest.mock('../../lib/sharedJsonFetch', () => ({
     fetchSharedJson: jest.fn(),
 }));
 
+const mockTrackEvent = jest.fn();
+jest.mock('../../lib/umami', () => ({
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
 const mockFetchSharedJson = fetchSharedJson as jest.MockedFunction<typeof fetchSharedJson>;
 
 const buildPayload = (overrides: Partial<BattleHistoryPayload> = {}): BattleHistoryPayload => ({
@@ -117,6 +122,7 @@ const mainFetchCalls = (mode?: string): unknown[] =>
 describe('BattleHistoryCard', () => {
     beforeEach(() => {
         mockFetchSharedJson.mockReset();
+        mockTrackEvent.mockReset();
         // Default response for the always-month sparkline fetch (second useEffect call).
         // Individual tests override the main window fetch via resolveWith().
         mockFetchSharedJson.mockResolvedValue({ data: buildPayload({ by_day: [] }), headers: {} });
@@ -376,6 +382,26 @@ describe('BattleHistoryCard', () => {
             const lastUrl = mockFetchSharedJson.mock.calls[beforeCount][0] as string;
             expect(lastUrl).toContain(`window=${w}`);
         }
+    });
+
+    test('fires name-baked player-history-<window> events when a non-active pill is picked', async () => {
+        resolveWith(buildPayload({ has_recent_24h_activity: true }));
+        render(<BattleHistoryCard playerName="lil_boots" realm="na" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('battle-history-card')).toBeInTheDocument();
+        });
+
+        // Default window is 'month', so switching to Week/Day fires distinct named events.
+        await act(async () => { screen.getByRole('button', { name: /^Week$/ }).click(); });
+        expect(mockTrackEvent).toHaveBeenCalledWith('player-history-week', expect.objectContaining({ realm: 'na' }));
+
+        await act(async () => { screen.getByRole('button', { name: /^Day$/ }).click(); });
+        expect(mockTrackEvent).toHaveBeenCalledWith('player-history-day', expect.objectContaining({ realm: 'na' }));
+
+        // Re-clicking the now-active Day pill does not re-fire.
+        mockTrackEvent.mockClear();
+        await act(async () => { screen.getByRole('button', { name: /^Day$/ }).click(); });
+        expect(mockTrackEvent).not.toHaveBeenCalledWith('player-history-day', expect.anything());
     });
 
     test('Day pill is disabled when has_recent_24h_activity is false', async () => {

--- a/client/app/components/__tests__/PlayerDetail.test.tsx
+++ b/client/app/components/__tests__/PlayerDetail.test.tsx
@@ -10,8 +10,13 @@ jest.mock('../../lib/sharedJsonFetch', () => ({
     decrementChartFetches: jest.fn(),
 }));
 
+jest.mock('../../lib/umami', () => ({
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
 const mockUseClanMembers = jest.fn();
 const mockClipboardWriteText = jest.fn();
+const mockTrackEvent = jest.fn();
 const mockClanSvg = jest.fn();
 let mockClanBattleSummary:
     | { seasonsPlayed: number; totalBattles: number; overallWinRate: number; }
@@ -119,6 +124,7 @@ describe('PlayerDetail efficiency-rank icon', () => {
 
     beforeEach(() => {
         mockUseClanMembers.mockReturnValue({ members: [], loading: false, error: null });
+        mockTrackEvent.mockReset();
         mockClanSvg.mockReset();
         mockClanBattleSummary = undefined;
         mockRankedHeatmapVisibility = undefined;
@@ -758,6 +764,23 @@ describe('PlayerDetail efficiency-rank icon', () => {
 
         expect(await screen.findByText('Copy failed')).toBeInTheDocument();
         expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('fires a player-share umami event when the share button is clicked', () => {
+        mockClipboardWriteText.mockResolvedValue(undefined);
+
+        render(
+            <PlayerDetail
+                player={basePlayer}
+                onBack={() => undefined}
+                onSelectMember={() => undefined}
+                onSelectClan={() => undefined}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Copy shareable player URL' }));
+
+        expect(mockTrackEvent).toHaveBeenCalledWith('player-share', expect.objectContaining({ realm: expect.any(String) }));
     });
 
     it('renders the default ships insight tab on the player page', async () => {

--- a/client/app/components/__tests__/PlayerDetailInsightsTabs.test.tsx
+++ b/client/app/components/__tests__/PlayerDetailInsightsTabs.test.tsx
@@ -10,6 +10,11 @@ jest.mock('../../lib/sharedJsonFetch', () => ({
     decrementChartFetches: jest.fn(),
 }));
 
+const mockTrackEvent = jest.fn();
+jest.mock('../../lib/umami', () => ({
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
 let mockRankedHeatmapVisibility: boolean | undefined;
 const mockFetchSharedJson = fetchSharedJson as jest.MockedFunction<typeof fetchSharedJson>;
 
@@ -66,6 +71,7 @@ jest.mock('../SectionHeadingWithTooltip', () => {
 describe('PlayerDetailInsightsTabs', () => {
     beforeEach(() => {
         mockRankedHeatmapVisibility = undefined;
+        mockTrackEvent.mockReset();
         mockFetchSharedJson.mockReset();
         mockFetchSharedJson.mockImplementation((url) => {
             if (url.includes('/api/fetch/player_correlation/tier_type/')) {
@@ -104,6 +110,37 @@ describe('PlayerDetailInsightsTabs', () => {
         expect(screen.queryByText('Loading profile charts...')).not.toBeInTheDocument();
         expect(screen.queryByText('Ranked Seasons')).not.toBeInTheDocument();
         expect(screen.queryByText('Efficiency Badges')).not.toBeInTheDocument();
+    });
+
+    it('fires name-baked player-insights events per tab (readable label, not the internal id)', () => {
+        render(
+            <PlayerDetailInsightsTabs
+                playerId={101}
+                pvpRatio={55}
+                pvpSurvivalRate={40}
+                pvpBattles={800}
+                playerScore={1.8}
+                hasKnownRankedGames
+                hasClan
+                efficiencyRows={[]}
+            />,
+        );
+
+        // Ships is the default tab; switching to others fires distinct named events.
+        fireEvent.click(screen.getByRole('tab', { name: 'Ranked' }));
+        expect(mockTrackEvent).toHaveBeenCalledWith('player-insights-ranked', expect.objectContaining({ realm: expect.any(String) }));
+
+        // 'Clan Battles' (id: career) and 'Efficiency' (id: badges) use the readable label slug.
+        fireEvent.click(screen.getByRole('tab', { name: 'Clan Battles' }));
+        expect(mockTrackEvent).toHaveBeenCalledWith('player-insights-clan-battles', expect.objectContaining({ realm: expect.any(String) }));
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Efficiency' }));
+        expect(mockTrackEvent).toHaveBeenCalledWith('player-insights-efficiency', expect.objectContaining({ realm: expect.any(String) }));
+
+        // Re-clicking the already-active tab does not re-fire.
+        mockTrackEvent.mockReset();
+        fireEvent.click(screen.getByRole('tab', { name: 'Efficiency' }));
+        expect(mockTrackEvent).not.toHaveBeenCalled();
     });
 
     it('switches across the insights tabs one at a time', () => {


### PR DESCRIPTION
## Summary

Captures the requested player-page interactions in Umami, following the name-baked convention (value in the event name → distinct realtime-feed rows). Analytics-only; no API/contract changes.

| Control | Now fires | Was |
|---|---|---|
| Share button | `player-share` | *(untracked)* |
| Battle-history window pills | `player-history-day` / `-week` / `-month` | *(untracked)* |
| Insights tabs | `player-insights-{ships,profile,ranked,clan-battles,efficiency,population}` | `insights-tab { tab: <internal id> }` |

Insights tabs use the **readable label** (`career`→`clan-battles`, `badges`→`efficiency`), per the chosen convention. Window/tab events fire only on an actual change (active-state guard); all carry `{ realm }`.

**No log/linear event** on the player page — its chart scales are backend-chosen in the payload, not a user toggle. The only user-facing log/linear toggle is on the clan page (instrumented in #29). Confirmed with the requester.

## Test coverage

Every new event is unit-tested (no d3 gaps this round): `PlayerDetail.test` (player-share), `BattleHistoryCard.test` (player-history-*), `PlayerDetailInsightsTabs.test` (player-insights-*). 73 pass across the three files.

## ⚠️ Merge/deploy ordering

This branch was cut from `main` **before #29 merged**, so it still contains the pre-#29 clan/treemap event names. **Merge #29 first**, then this — deploying a tree without #29's changes would revert the clan + treemap events currently live in prod.

## Umami dashboard note

`insights-tab` joins `chart-scale` / `clan-chart-mode` / `treemap-mode` on the list of renamed events — any saved Umami report/widget keyed on the old names should be re-pointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)