### PR TITLE
fix(battle-history): gate dormant period rollup off to fix nightly 540s timeout

### DIFF
--- a/agents/runbooks/ops-env-reference.md
+++ b/agents/runbooks/ops-env-reference.md
@@ -34,6 +34,7 @@ Battle-history pipeline (phased gates, all default 0):
 - `BATTLE_HISTORY_CAPTURE_ENABLED` (write BattleObservation/BattleEvent as a side-effect of `update_battle_data`)
 - `BATTLE_HISTORY_ROLLUP_ENABLED` + `_HOUR`/`_MINUTE` (4/30) (fill PlayerDailyShipStats + nightly rebuild)
 - `BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS` (3) — trailing-window size the nightly sweeper rebuilds (self-heal); `1` = legacy yesterday-only. See `runbook-battle-history-rollup-durability-2026-06-06.md`.
+- `BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED` (0) — gates the nightly weekly/monthly/yearly rebuild; OFF by default because those tiers are dormant/UI-hidden and the yearly-YTD aggregate is the long pole that exceeded the task's 540s soft time limit (the daily layer still builds). Flip to `1` only when the period tiers are reactivated.
 - `BATTLE_HISTORY_RECONCILE_ENABLED` (0) — gates the alert-only rollup reconciliation task; **independent** of `BATTLE_HISTORY_ROLLUP_ENABLED` (so it can detect rollup-off / holes)
 - `BATTLE_HISTORY_RECONCILE_AUDIT_DAYS` (30) — audit window the reconciliation task scans
 - `BATTLE_HISTORY_API_ENABLED` (exposes `GET /api/player/<name>/battle-history?days=N`, 404 when off)

--- a/agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
+++ b/agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md
@@ -69,6 +69,11 @@ PlayerDailyShipStats ─count──┤
 - Preserve `target_date_iso` for manual single-date runs; when supplied, lookback collapses to 1 (one day, one period pass) — back-compatible with the existing manual/`rebuild` semantics.
 - Add a **single-run global lock** (`cache.add(_task_lock_key("roll_up_player_daily_ship_stats","global"), …)`, pattern at `tasks.py:1797-1826`) since the windowed run outlasts a single day and could overlap a slow prior run.
 - Keep the `BATTLE_HISTORY_ROLLUP_ENABLED` gate and the start/finish log lines; log a per-run summary `{days_rebuilt, periods_rebuilt, per-day result dicts}`.
+- **Period rebuild is gated OFF by default** (`BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED`, default 0) — see "Operational note" below. When off, the daily layer still rebuilds and `period` is reported `{"status":"skipped","reason":"period-rollup-disabled"}`.
+
+#### Operational note — period rebuild gated off (B1 rollout, 2026-06-06)
+
+The B1 rollout verification found the nightly task hitting `SoftTimeLimitExceeded` (540s soft / 600s hard, from `TASK_OPTS`) **inside the period rebuild** (`rebuild_period_rollups_for_window` → the yearly-YTD `_aggregate_into_period_table` scan), *after* the daily layer had completed in seconds. The daily layer is the only consumed + reconciled tier; the weekly/monthly/yearly tiers are dormant + UI-hidden. So the period rebuild is now gated behind `BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED` (default 0): the nightly self-heal stays fast and error-free, and the long pole only runs when explicitly enabled. The proper fix when the tiers are reactivated is the deferred DB-side rewrite (see Out of scope). Re-enabling without that rewrite will re-introduce the timeout.
 
 ### 2. BRIN index + half-open range filter — guarded migration + `incremental_battles.py`
 
@@ -165,13 +170,14 @@ Extend the existing suites (`RebuildDailyShipStatsTests` 1481, `RankedRollupWrit
 
 - **DB-side rewrite of `rebuild_daily_ship_stats_for_date`** — retires the `TODO(2026-Q3)` at `incremental_battles.py:982-985`; prerequisite for a *wide* lookback window (the current per-day Python load is only safe at small N).
 - **Gap B accuracy** — battle-time attribution / observation-floor density work.
-- **Reactivating the weekly/monthly/yearly period tiers in the UI** — they remain dormant; this work only keeps them internally consistent via the dedup'd rebuild.
+- **Reactivating the weekly/monthly/yearly period tiers in the UI** — they remain dormant and the nightly period rebuild is gated OFF (`BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED=0`, see Operational note). Reactivation should land together with the DB-side rewrite above, then flip the flag — otherwise the 540s timeout returns.
 
 ## Env knobs (full catalog in `ops-env-reference.md`)
 
 | Knob | Default | Effect |
 |---|---|---|
 | `BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS` | `3` | Trailing-window size the nightly sweeper rebuilds (self-heal). `1` = legacy yesterday-only. |
+| `BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED` | `0` | Gates the nightly weekly/monthly/yearly rebuild (the 540s long pole). OFF by default; flip only when period tiers are reactivated (with the DB-side rewrite). |
 | `BATTLE_HISTORY_RECONCILE_ENABLED` | `0` | Gates the alert-only reconciliation task; independent of `BATTLE_HISTORY_ROLLUP_ENABLED`. |
 | `BATTLE_HISTORY_RECONCILE_AUDIT_DAYS` | `30` | Audit window the reconciliation task scans. |
 

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -1749,6 +1749,11 @@ def roll_up_player_daily_ship_stats_task(self, target_date_iso=None):
     A single explicit `target_date_iso` collapses the window to that one day
     (manual single-date repair), matching the legacy behaviour.
 
+    The weekly/monthly/yearly period rebuild is gated OFF by default
+    (BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED) — those tiers are dormant + UI-hidden
+    and the yearly-YTD aggregate is the long pole that blew the 540s soft time
+    limit, while the daily layer (consumed + reconciled) completes in seconds.
+
     See agents/runbooks/runbook-battle-history-rollup-durability-2026-06-06.md.
     """
     if os.getenv("BATTLE_HISTORY_ROLLUP_ENABLED", "0") != "1":
@@ -1792,16 +1797,28 @@ def roll_up_player_daily_ship_stats_task(self, target_date_iso=None):
             dates[0], dates[-1], len(dates))
         daily_results = [rebuild_daily_ship_stats_for_date(d) for d in dates]
         # Cascade into the weekly / monthly / yearly tiers covering the window,
-        # each distinct period rebuilt once, so coarser views always reflect
-        # the latest daily layer.
-        period_result = rebuild_period_rollups_for_window(dates)
-        logger.info(
-            "Finished roll_up_player_daily_ship_stats_task: days_rebuilt=%d "
-            "periods_rebuilt=w%d/m%d/y%d",
-            len(daily_results),
-            period_result["weeks_rebuilt"],
-            period_result["months_rebuilt"],
-            period_result["years_rebuilt"])
+        # each distinct period rebuilt once. Gated OFF by default: those tiers
+        # are dormant + UI-hidden and the yearly-YTD aggregate is the long pole
+        # that exceeded the 540s soft time limit, whereas the daily layer above
+        # finishes in seconds. Flip BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED=1 to
+        # refresh the coarser tiers (pair with the deferred DB-side rewrite when
+        # they are reactivated for the UI).
+        if os.getenv("BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED", "0") == "1":
+            period_result = rebuild_period_rollups_for_window(dates)
+            logger.info(
+                "Finished roll_up_player_daily_ship_stats_task: days_rebuilt=%d "
+                "periods_rebuilt=w%d/m%d/y%d",
+                len(daily_results),
+                period_result["weeks_rebuilt"],
+                period_result["months_rebuilt"],
+                period_result["years_rebuilt"])
+        else:
+            period_result = {"status": "skipped",
+                             "reason": "period-rollup-disabled"}
+            logger.info(
+                "Finished roll_up_player_daily_ship_stats_task: days_rebuilt=%d "
+                "period_rebuild=skipped (BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED!=1)",
+                len(daily_results))
         return {
             "status": "completed",
             "days_rebuilt": len(daily_results),

--- a/server/warships/tests/test_incremental_battles.py
+++ b/server/warships/tests/test_incremental_battles.py
@@ -3637,6 +3637,36 @@ class RollupDurabilityTests(TestCase):
         self.assertTrue(PlayerWeeklyShipStats.objects.filter(
             period_start=monday).exists())
 
+    def test_period_rebuild_skipped_by_default(self):
+        # Period tiers are dormant + UI-hidden and are the long pole that blew
+        # the 540s soft limit, so the nightly sweeper skips them unless
+        # BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED=1. The daily layer still builds.
+        self._event_on(self.yesterday, battles=2)
+        result = self._run_sweeper(lookback=3)
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["period"]["status"], "skipped")
+        self.assertEqual(result["period"]["reason"], "period-rollup-disabled")
+        self.assertTrue(
+            PlayerDailyShipStats.objects.filter(date=self.yesterday).exists())
+        self.assertEqual(PlayerWeeklyShipStats.objects.count(), 0)
+        self.assertEqual(PlayerMonthlyShipStats.objects.count(), 0)
+        self.assertEqual(PlayerYearlyShipStats.objects.count(), 0)
+
+    def test_period_rebuild_runs_when_flag_enabled(self):
+        from warships.incremental_battles import _week_start
+        from warships.tasks import roll_up_player_daily_ship_stats_task
+        self._event_on(self.yesterday, battles=2)
+        with mock.patch.dict("os.environ", {
+            "BATTLE_HISTORY_ROLLUP_ENABLED": "1",
+            "BATTLE_HISTORY_ROLLUP_LOOKBACK_DAYS": "3",
+            "BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED": "1",
+        }):
+            result = roll_up_player_daily_ship_stats_task.apply().get()
+        self.assertEqual(result["status"], "completed")
+        self.assertGreaterEqual(result["period"]["weeks_rebuilt"], 1)
+        self.assertTrue(PlayerWeeklyShipStats.objects.filter(
+            period_start=_week_start(self.yesterday)).exists())
+
 
 class RollupReconciliationTests(TestCase):
     """Alert-only reconciliation of PlayerDailyShipStats vs BattleEvent.


### PR DESCRIPTION
Follow-up to #28. The B1 rollout verification found the nightly rollup task hitting `SoftTimeLimitExceeded` (540s) **inside the weekly/monthly/yearly rebuild** (the yearly-YTD `_aggregate_into_period_table` scan) — *after* the daily layer (the only consumed + reconciled tier) had already completed in seconds. The period tiers are dormant + UI-hidden, so rebuilding them nightly was pure cost and the only thing blowing the time budget.

## Change
- Gate the period rebuild behind **`BATTLE_HISTORY_PERIOD_ROLLUP_ENABLED`** (default `0`). When off, the daily self-heal still runs and the task reports `period={"status":"skipped","reason":"period-rollup-disabled"}`.
- Flip to `1` only when the period tiers are reactivated for the UI — and pair with the deferred DB-side rewrite, or the timeout returns.

## Tests / docs
- +2 tests (`test_period_rebuild_skipped_by_default`, `test_period_rebuild_runs_when_flag_enabled`); `test_incremental_battles` = 151 passed, curated backend gate = 262 passed, `makemigrations --check` clean.
- `ops-env-reference.md` + `runbook-battle-history-rollup-durability-2026-06-06.md` updated (new "Operational note" documenting the timeout finding + gate).

No migration. No user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)