### PR TITLE
feat(landing): treemap→leaderboard in-place drill-down + T9-submarine easter egg

### DIFF
--- a/agents/doc_registry.json
+++ b/agents/doc_registry.json
@@ -2229,6 +2229,30 @@
                 "crawl-control-model-replaced"
             ]
         },
+        "agents/runbooks/runbook-ship-leaderboard-submarine-easter-egg-2026-06-11.md": {
+            "kind": "runbook",
+            "status": "active",
+            "lifecycle": "dated-active",
+            "section": "frontend",
+            "owner": "product",
+            "aliases": [
+                "submarine easter egg",
+                "t9 submarine",
+                "ascii sub",
+                "ship leaderboard easter egg"
+            ],
+            "tags": [
+                "frontend",
+                "feature",
+                "landing-page",
+                "ship-leaderboard",
+                "easter-egg",
+                "ux"
+            ],
+            "archive_on": [
+                "submarine-easter-egg-superseded"
+            ]
+        },
         "agents/runbooks/runbook-treemap-shipleaderboard-handoff-2026-06-12.md": {
             "kind": "runbook",
             "status": "active",

--- a/agents/doc_registry.json
+++ b/agents/doc_registry.json
@@ -2228,6 +2228,30 @@
             "archive_on": [
                 "crawl-control-model-replaced"
             ]
+        },
+        "agents/runbooks/runbook-treemap-shipleaderboard-handoff-2026-06-12.md": {
+            "kind": "runbook",
+            "status": "active",
+            "lifecycle": "dated-active",
+            "section": "frontend",
+            "owner": "product",
+            "aliases": [
+                "treemap drill-down",
+                "treemap to leaderboard",
+                "ship leaderboard handoff",
+                "in-place ship board"
+            ],
+            "tags": [
+                "frontend",
+                "feature",
+                "landing-page",
+                "treemap",
+                "ship-leaderboard",
+                "ux"
+            ],
+            "archive_on": [
+                "treemap-leaderboard-handoff-superseded"
+            ]
         }
     }
 }

--- a/agents/runbooks/runbook-ship-leaderboard-submarine-easter-egg-2026-06-11.md
+++ b/agents/runbooks/runbook-ship-leaderboard-submarine-easter-egg-2026-06-11.md
@@ -1,0 +1,323 @@
+# Runbook — Ship Leaderboard "Tier 9 Submarine" ASCII-Sub Easter Egg (2026-06-11)
+
+**Status:** IMPLEMENTED (2026-06-12). Built per this plan: a single new client component
+(`SubmarineEasterEgg.tsx`) + the parent short-circuit wiring change in `ShipLeaderboard.tsx`, with a
+wiring test. Scope: a single new client component + a four-line wiring change.
+
+## Why
+
+The `ShipLeaderboard` inline explorer (`client/app/components/ShipLeaderboard.tsx`) lets a user pick
+any **tier ∈ {8, 9, 10}** × **type ∈ {Battleship, Cruiser, Destroyer, AirCarrier, Submarine}**
+combination from hardcoded pill rows. Several of those combinations have **no ships in World of
+Warships** — most notably **Tier 9 Submarines** and **Tier 9 Aircraft Carriers** (subs and CVs skip
+odd tiers). Today, picking T9 + Submarine shows a flat dead-end:
+
+> No ranked ships for T9 Submarine.
+
+That dead-end is an opportunity. This plan replaces the T9-Submarine message with a small,
+theme-aware **D3 animation of an ASCII submarine cruising left→right** — a delight/easter-egg moment
+for the curious player who pokes at impossible combinations.
+
+**Goal:** code a D3 SVG animation (900 × 300px, transparent background, theme-aware) and render it in
+place of the "No ranked ships for T9 Submarine." text for the **T9 + Submarine** combination only.
+
+## Scope decisions (read before building)
+
+- **T9 Submarine only.** T9 Carrier is the *exact same empty-bucket pattern* and a natural follow-up,
+  but it is **out of scope** here — this is a deliberate cut, not an oversight. Extending to CV later
+  is a one-line predicate change (see "Future extension").
+- **No new telemetry event.** Discovery is already measurable: selecting the Submarine pill fires the
+  existing `trackEvent('ship-leaderboard-filter', { realm, control: 'type', tier: 9, type: 'Submarine' })`
+  (`ShipLeaderboard.tsx:201-206`). Do **not** add a redundant event.
+- **Minor version bump** on ship (new user-facing surface/UX per `CLAUDE.md` Versioning). Remember the
+  mandatory client rebuild after any bump.
+
+## Where it plugs in (verified against code)
+
+The tier/type picker and the empty-state branches live in **`ShipLeaderboard.tsx`** (the inline
+explorer under the landing treemap) — **not** `ShipRouteView.tsx` (that is the single-ship
+`/ship/[slug]` page and has no tier/type picker). The render switch is at
+`ShipLeaderboard.tsx:321-346`:
+
+```tsx
+<div className="mt-4">
+    {!bothSelected ? (
+        <p className="py-6 text-sm text-[var(--text-muted)]">
+            Pick a tier and a type to rank ships by win rate.
+        </p>
+    ) : selectedShip ? (
+        <ShipBoard … />
+    ) : (
+        <ShipList … />     // ← renders "No ranked ships for T9 Submarine." when the list is empty
+    )}
+</div>
+```
+
+The "No ranked ships for {tierTypeLabel}." text itself is in `ShipList` at `ShipLeaderboard.tsx:376-378`.
+
+## Approach: parent short-circuit (no fetch) — THE decision
+
+Render the easter egg directly from the parent render switch, **before** any fetch, when
+`tier === 9 && type === 'Submarine'`:
+
+```tsx
+    ) : tier === 9 && type === 'Submarine' ? (
+        <SubmarineEasterEgg />
+    ) : selectedShip ? (
+```
+
+Insert this branch **between** the `!bothSelected` check and the `selectedShip` check. This is safe:
+`chooseTier`/`chooseType` both `setSelectedShip(null)` (`ShipLeaderboard.tsx:195-206`), so the T9+SS
+combo can never carry a stale drilldown into this branch.
+
+### Why short-circuit, not "gate on the empty list" — REJECTED ALTERNATIVE
+
+Gating the easter egg on `sortedShips.length === 0` inside `ShipList` was considered and **rejected**:
+
+1. **It 400s in local dev and any env where `SHIP_BADGE_TIERS` excludes 9.** `data._badge_tiers()`
+   (`data.py:6187-6193`) defaults to `'10'` when `SHIP_BADGE_TIERS` is unset, and `local server/.env`
+   ships that default. The `/api/realm/<realm>/ships?tier=9&type=Submarine` endpoint validates `tier`
+   against `_badge_tiers()` and returns **400** for T9 locally (`views.py` ship-list validation,
+   ~2085-2131) → the list lands in the *error* branch ("Couldn't load ships."), never the *empty*
+   branch. The easter egg would silently fail to appear in dev, and QA would require an env edit.
+2. The short-circuit makes **backend behavior irrelevant** (no fetch at all), so it works in **every**
+   environment with **no env change**, avoids a pointless round-trip, and removes the brief
+   "Loading ships…" flash before the empty state resolves.
+
+Trade-off accepted: the short-circuit would *mask a real T9 submarine* if World of Warships ever added
+one. For a whimsical easter egg on a tier that has never had a sub, that is the correct trade. (For the
+record: in **prod**, `SHIP_BADGE_TIERS='8,9,10'`, so T9 is valid and the endpoint would return an empty
+`200` — `'Submarine' ∈ SHIP_LEADERBOARD_TYPES`, `data.py:6557` — but we still don't fetch it.)
+
+## New component: `client/app/components/SubmarineEasterEgg.tsx`
+
+A self-contained client component following the established D3 chart pattern (`useRef` + `useEffect` +
+`d3.select` direct DOM manipulation; D3 `^7.9.0`, `client/package.json:18`) used by `TierSVG.tsx`,
+`TypeSVG.tsx`, etc.
+
+### Requirements
+
+| Requirement | Decision |
+|---|---|
+| Dimensions | **900 × 300** px (`viewBox="0 0 900 300"`, `max-width: 900px`, `width: 100%` for responsive scale-down) |
+| Background | **Transparent** — inherits the host page background (`--bg-page`), which is exactly "the background of the component and site" and is theme-aware *for free*. Do not paint a fill rect. |
+| Theme awareness | Read `chartColors[theme]` via `useTheme()` (`app/context/ThemeContext.tsx`), exactly like `TierSVG.tsx:256`. Sub body uses **`colors.shipSS`** — the submarine-class purple (`#7c3aed` light / `#a78bfa` dark, `chartTheme.ts:102,157`), thematically perfect. Re-render on theme toggle via `theme` in the effect deps. |
+| Motion | ASCII sub translates **left→right** across the full 900px, looping forever, with a gentle vertical bob (sine). Linear ease, ~12s per crossing. |
+| Geometry | **No `getBBox()`** — see "Tested assumptions". All bounds are fixed constants computed from the known monospace art. |
+| Facing | Art faces its **natural direction**; animate left→right. **No runtime `scale(-1,1)` flip** (it inverts the translate coordinate system and runs the animation backwards). If bow-forward is ever wanted, hand-mirror the literal strings in `SUB_ART` — do not transform. |
+| Accessibility | `role="img"` + `aria-label`; honor `prefers-reduced-motion: reduce` by rendering the sub **static, centered** (no transition). |
+| Cleanup | On unmount / theme change, `.interrupt()` the transition and clear the SVG to avoid leaked rAF/transition loops. |
+
+### The ASCII art
+
+Inspired by https://ascii.co.uk/art/submarine (artist "dr"). Compact (4 lines), clearly a sub with
+sail + periscope. Signature trimmed. **Render each line as its own left-anchored `<tspan>`** so
+per-line alignment (the only alignment that matters) is preserved; keep leading spaces verbatim.
+
+```
+         |\_
+   _____|~ |____
+  (  --         ~~~~--_,
+   ~~~~~~~~~~~~~~~~~~~'`
+```
+
+As a JS string array (note the escaped backslash and the single backtick on the last line):
+
+```tsx
+const SUB_ART = [
+    '         |\\_',
+    '   _____|~ |____',
+    '  (  --         ~~~~--_,',
+    "   ~~~~~~~~~~~~~~~~~~~'`",
+];
+```
+
+### Reference implementation (copy-paste starting point)
+
+```tsx
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+import { useTheme } from '../context/ThemeContext';
+import { chartColors } from '../lib/chartTheme';
+
+const SUB_ART = [
+    '         |\\_',
+    '   _____|~ |____',
+    '  (  --         ~~~~--_,',
+    "   ~~~~~~~~~~~~~~~~~~~'`",
+];
+
+const WIDTH = 900;
+const HEIGHT = 300;
+const FONT_SIZE = 18;
+const LINE_H = 22;
+const CROSS_MS = 12000;
+// Fixed off-screen bounds (no getBBox). At ~0.6em/char monospace, the widest
+// line (~23 chars) is ~250px; -360 → WIDTH+60 fully clears both edges.
+const X_START = -360;
+const X_END = WIDTH + 60;
+const BLOCK_H = SUB_ART.length * LINE_H;
+const Y_MID = (HEIGHT - BLOCK_H) / 2;
+
+const SubmarineEasterEgg: React.FC = () => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const { theme } = useTheme();
+
+    useEffect(() => {
+        const host = ref.current;
+        if (!host) return;
+        const colors = chartColors[theme];
+
+        d3.select(host).selectAll('*').remove();
+
+        const svg = d3
+            .select(host)
+            .append('svg')
+            .attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`)
+            .attr('width', '100%')
+            .attr('role', 'img')
+            .attr('aria-label', 'There are no Tier 9 submarines — but here is one anyway.')
+            .style('display', 'block')
+            .style('max-width', `${WIDTH}px`)
+            .style('background', 'transparent');
+
+        const g = svg.append('g');
+        const text = g
+            .append('text')
+            .attr('font-family', 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace')
+            .attr('font-size', FONT_SIZE)
+            .attr('fill', colors.shipSS)
+            .style('white-space', 'pre');
+
+        SUB_ART.forEach((line, i) => {
+            text
+                .append('tspan')
+                .attr('x', 0)
+                .attr('y', i * LINE_H + FONT_SIZE)
+                .attr('xml:space', 'preserve')
+                .text(line);
+        });
+
+        const reduce =
+            typeof window !== 'undefined' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        if (reduce) {
+            // Static, roughly centered (no animation).
+            g.attr('transform', `translate(${(WIDTH - 250) / 2}, ${Y_MID})`);
+            return () => {
+                d3.select(host).selectAll('*').remove();
+            };
+        }
+
+        let stopped = false;
+        const swim = () => {
+            if (stopped) return;
+            g.attr('transform', `translate(${X_START}, ${Y_MID})`)
+                .transition()
+                .duration(CROSS_MS)
+                .ease(d3.easeLinear)
+                .attrTween('transform', () => {
+                    const ix = d3.interpolateNumber(X_START, X_END);
+                    return (t: number) => {
+                        const x = ix(t);
+                        const bob = Math.sin(t * Math.PI * 4) * 8; // gentle vertical bob
+                        return `translate(${x}, ${Y_MID + bob})`;
+                    };
+                })
+                .on('end', swim);
+        };
+        swim();
+
+        return () => {
+            stopped = true;
+            d3.select(host).selectAll('*').interrupt();
+            d3.select(host).selectAll('*').remove();
+        };
+    }, [theme]);
+
+    return <div ref={ref} className="w-full" style={{ maxWidth: WIDTH }} />;
+};
+
+export default SubmarineEasterEgg;
+```
+
+### Optional polish (not required for v1)
+
+- Bubble trail: a few small `<circle>` elements parented to `g`, drifting up with their own
+  per-bubble tween. Use `colors.wrNull` / `colors.accentMid` so they stay theme-aware.
+- A faint waterline: a single horizontal `<line>` at `y ≈ HEIGHT*0.5` in `colors.gridLine`.
+
+Keep v1 to the sub itself; add polish only if cheap.
+
+## Wiring change in `ShipLeaderboard.tsx`
+
+1. Add the import near the other component imports at the top of the file:
+   ```tsx
+   import SubmarineEasterEgg from './SubmarineEasterEgg';
+   ```
+2. Add the branch in the render switch (`~line 326`), between `!bothSelected` and `selectedShip`:
+   ```tsx
+       ) : tier === 9 && type === 'Submarine' ? (
+           <SubmarineEasterEgg />
+       ) : selectedShip ? (
+   ```
+   `tier` is typed `Tier | null` (`8 | 9 | 10`) and `type` is `ShipType | null` (includes
+   `'Submarine'`), so the predicate type-checks with no casts.
+
+No backend, API, or model changes. No new env vars or kill switches.
+
+## Tested technical assumptions (QA of this plan)
+
+| Assumption | Verified? | Evidence |
+|---|---|---|
+| Picker + empty message live in `ShipLeaderboard.tsx`, not `ShipRouteView.tsx` | ✅ | Tier/type pills `ShipLeaderboard.tsx:286-318`; message `:376-378`; render switch `:321-346` |
+| `'Submarine'` is an accepted type (so the combo is reachable, message currently renders) | ✅ | `SHIP_LEADERBOARD_TYPES` includes `'Submarine'` (`data.py:6557`); pill set includes it (`ShipLeaderboard.tsx:27`) |
+| **Gate-on-empty would 400 in local/dev** (the decisive reason for short-circuit) | ✅ | `_badge_tiers()` defaults to `'10'` (`data.py:6187-6193`); local `.env` ships that default (memory: *local SHIP_BADGE_TIERS default*); T9 → 400 → error branch, not empty branch |
+| Combo can't carry a stale drilldown into the new branch | ✅ | `chooseTier`/`chooseType` both `setSelectedShip(null)` (`:195-206`) |
+| Theme pattern: `useTheme()` → `chartColors[theme]`, re-render on `theme` dep | ✅ | `TierSVG.tsx:248-272`; `chartTheme.ts` exports `shipSS` etc. |
+| D3 version supports `attrTween`/`interpolateNumber`/`easeLinear` | ✅ | D3 `^7.9.0` (`package.json:18`) |
+| **`getBBox()` is unsafe and unnecessary** — eliminated | ✅ | jsdom returns zeros (breaks tests); returns 0 under any `display:none` ancestor; conflicts with flip transforms. Geometry is fixed arithmetic from known monospace art — no measurement needed. |
+| Transparent SVG bg == "component and site background", theme-aware | ✅ | Host section sits on `--bg-page` (`globals.css:6,35`); transparent inherits it in both themes |
+
+## Test coverage (doctrine requirement #3)
+
+The animation internals are not jsdom-testable (no real layout/rAF), and we removed `getBBox`, so the
+worthwhile test is at the **wiring/branch** level, not the D3 internals:
+
+- New `client/app/components/__tests__/ShipLeaderboard.test.tsx` (or add to an existing one):
+  render `<ShipLeaderboard />`, click the **T9** pill then the **Submarine (SS)** pill, and assert:
+  1. the easter-egg container renders — query by its `aria-label`
+     (`There are no Tier 9 submarines…`) or add a `data-testid`;
+  2. the text `No ranked ships` is **absent**;
+  3. no `/api/.../ships?tier=9&type=Submarine` fetch is issued (assert the `fetchSharedJson`/fetch mock
+     was not called for that combo) — proves the short-circuit.
+- Mock `useRealm`/`trackEvent`/`fetchSharedJson` as the existing component tests do. The test exercises
+  the **branch**, not the animation. If `SubmarineEasterEgg`'s D3 effect is noisy in jsdom, mock the
+  module (`jest.mock('../SubmarineEasterEgg', …)`) to a stub that renders the `aria-label` container.
+
+## Validation checklist before shipping
+
+1. `cd client && npx tsc --noEmit` and `npm run lint` clean (local FE validation per project memory:
+   the Docker release gate is authoritative; local `run_release_gate.sh` has a pre-existing d3-ESM
+   failure unrelated to this change).
+2. `npm run build` succeeds.
+3. `npm test -- ShipLeaderboard` passes the new wiring test.
+4. **Manual visual QA** (mandatory — lint/build/CI don't catch visual regressions; memory: *verify
+   UX/layout changes visually before deploy*):
+   - `npm run dev`, open the surface hosting `ShipLeaderboard`, pick **T9 → SS**.
+   - Confirm: sub cruises left→right and loops; background matches the page (no box/edge); toggle
+     theme — sub recolors (purple light↔dark) with no leaked/duplicated animation; 900×300 footprint;
+     scales down gracefully on a narrow viewport. No console errors.
+   - Set OS "reduce motion" → confirm a static centered sub, no animation.
+   - **No env change needed** to reproduce locally — that's the payoff of the short-circuit.
+5. Doctrine pre-commit: this runbook documents the behavior; the wiring test covers it. On
+   implementation, mark this runbook **IMPLEMENTED** with the date.
+
+## Future extension (deliberately deferred)
+
+T9 **AirCarrier** is the identical empty bucket. To cover it, broaden the predicate — e.g.
+`tier === 9 && (type === 'Submarine' || type === 'AirCarrier')` — and either reuse the sub (whimsy
+over realism) or add a parallel ASCII-CV component. Out of scope for this runbook.

--- a/agents/runbooks/runbook-treemap-shipleaderboard-handoff-2026-06-12.md
+++ b/agents/runbooks/runbook-treemap-shipleaderboard-handoff-2026-06-12.md
@@ -1,0 +1,92 @@
+# Runbook: Treemap → ShipLeaderboard In-Place Drill-Down
+
+## Summary
+
+On the landing page, clicking a tile in the realm most-played-ships treemap
+(`RealmTopShipsTreemapSVG`) now drills **straight to that ship's best-player board inside the inline
+`ShipLeaderboard`** that sits directly below it — in place, no navigation. The treemap sets the
+leaderboard's tier + type to the clicked ship and opens its player board, scrolling the leaderboard
+into view. The standalone `/ship/<id>` route is unchanged and remains the fallback for tiles the
+leaderboard can't represent (sub-T8, null tier, unknown type).
+
+This is a **frontend-only** change. No backend, API, payload, or DB work — both surfaces already
+consume `/api/realm/<realm>/top-ships` and `/api/realm/<realm>/ship/<id>/leaderboard`.
+
+## UI Behavior
+
+- **Supported tile** (tier 8/9/10 + one of BB/CA/DD/CV/SS): click sets the leaderboard tier+type
+  pills to match, opens that ship's player board in place, and smooth-scrolls the leaderboard
+  section into view. Clicking **Clear** in the board returns to the ship list for that same
+  tier+type (proving the filters were set, not just the board).
+- **Unsupported tile** (sub-T8, null tier, or a type outside the five canonical classes): falls back
+  to the existing full-page `router.push('/ship/<id>')` navigation. No tile is a dead click.
+- **Both treemap modes** (Random / Ranked) drill to the same season-snapshot board the leaderboard
+  already fetches — identical to the prior `/ship/<id>` navigation, so no new data inconsistency.
+
+## Handoff Contract
+
+The bridge is a one-shot **imperative command**, not lifted state. `ShipLeaderboard` exposes a ref
+handle; the treemap calls it through the shared parent `PlayerSearch`. This keeps the leaderboard's
+large internal state cluster (list / board / loading / error / sort) encapsulated and avoids
+prop↔state sync races (e.g. a prop re-applying after the user hits Clear).
+
+```
+RealmTopShipsTreemapSVG  --onSelect(sel)-->  PlayerSearch  --ref.selectShip(sel)-->  ShipLeaderboard
+```
+
+### `ShipLeaderboardHandle`
+
+```ts
+export interface ShipLeaderboardHandle {
+    selectShip(sel: { id: number; name: string; tier: Tier; type: ShipType }): void;
+}
+```
+
+`selectShip` sets `tier`, `type`, and `selectedShip` directly (not via the `chooseTier`/`chooseType`
+pill handlers, which no-op on unchanged values and clear `selectedShip`), then scrolls the section
+into view. Setting `selectedShip` fires the board fetch effect (straight to the board); the list
+effect stays dormant while `selectedShip` is truthy. Setting tier/type directly means a later
+**Clear** lands on the correct tier/type ship list.
+
+The three `setState` calls run inside a native D3 click listener; React 18 automatic batching
+collapses them into one render, so no intermediate render with the new tier/type + null
+`selectedShip` fires a wasted list fetch.
+
+`Tier`, `ShipType`, and `SHIP_TYPES` are exported from `ShipLeaderboard.tsx` and reused by the
+treemap to gate which tiles drill in place vs. fall back to the route.
+
+### Stale-closure guard (treemap)
+
+The treemap's click handler is bound inside its D3 render `useEffect`. To pick up the latest
+`onSelect` without rebuilding the D3 tree, the callback is mirrored into a ref
+(`onSelectRef`) updated every render, and the handler reads `onSelectRef.current`. The render
+effect's dependency array is unchanged.
+
+## Analytics
+
+- `treemap-ship` now carries `target: 'leaderboard' | 'route'` distinguishing the in-place drill
+  from the fallback navigation.
+- `ship-leaderboard-drilldown` carries `source: 'treemap' | 'row'` distinguishing a treemap handoff
+  from a ship-list row click.
+
+## Files
+
+- `client/app/components/ShipLeaderboard.tsx` — `forwardRef` + `useImperativeHandle` handle, exports.
+- `client/app/components/RealmTopShipsTreemapSVG.tsx` — `onSelect` prop, `onSelectRef`, click branch.
+- `client/app/components/PlayerSearch.tsx` — ref bridge between the two siblings.
+- `client/app/components/__tests__/ShipLeaderboard.test.tsx` — handle test.
+
+## Verification
+
+1. `cd client && npx tsc --noEmit && npm run lint && npm run build`.
+2. `cd client && npm test -- app/components/__tests__/ShipLeaderboard.test.tsx`.
+3. Manual (`npm run dev`, port 3000): click a T10 DD tile → board in place; Clear → T10 DD list;
+   T10 CV tile → CV board; sub-T8 tile (if present) → `/ship/<id>` navigation; Ranked mode → still
+   in place; repeat on EU/ASIA for realm consistency. DevTools: one
+   `/api/realm/<realm>/ship/<id>/leaderboard` request, no full document load.
+
+## Out of Scope
+
+- Any change to the `/ship/<id>` route, its payload, or backend endpoints.
+- Highlighting the originating tile or syncing treemap mode into the leaderboard.
+- Lifting leaderboard state into the parent (rejected in favor of the imperative handle).

--- a/client/app/components/PlayerSearch.tsx
+++ b/client/app/components/PlayerSearch.tsx
@@ -9,7 +9,7 @@ import ClanDetail from './ClanDetail';
 import EfficiencyRankIcon, { resolveEfficiencyRankTier, type EfficiencyRankTier } from './EfficiencyRankIcon';
 import PlayerDetail from './PlayerDetail';
 import RealmTopShipsTreemapSVG from './RealmTopShipsTreemapSVG';
-import ShipLeaderboard from './ShipLeaderboard';
+import ShipLeaderboard, { type ShipLeaderboardHandle } from './ShipLeaderboard';
 import { resilientDynamicImport } from './resilientDynamicImport';
 import type { LandingClan, LandingPlayer, PlayerData } from './entityTypes';
 import { buildClanPath, buildPlayerPath } from '../lib/entityRoutes';
@@ -225,6 +225,7 @@ const PlayerSearch: React.FC = () => {
     const [playerBestSort, setPlayerBestSort] = useState<PlayerBestSort>('overall');
     const lastSubmittedSearchRef = useRef<string>('');
     const bestLandingWarmupRequestedRef = useRef(false);
+    const shipLeaderboardRef = useRef<ShipLeaderboardHandle>(null);
 
     const fetchLandingClans = useCallback(async (sort: ClanBestSort = 'overall') => {
         const params = new URLSearchParams({
@@ -476,12 +477,16 @@ const PlayerSearch: React.FC = () => {
                         reverted — it glued the strip to the viewport's left
                         edge; see runbook-audience-device-optimization). */}
                     <div className="mt-2 pt-6">
-                        <RealmTopShipsTreemapSVG />
+                        <RealmTopShipsTreemapSVG
+                            onSelect={(sel) => shipLeaderboardRef.current?.selectShip(sel)}
+                        />
                     </div>
 
                     {/* Inline ship leaderboard: filter by tier+type, rank ships by
-                        win rate, drill into any ship's player board in place. */}
-                    <ShipLeaderboard />
+                        win rate, drill into any ship's player board in place. A
+                        treemap tile click hands off here via the ref (in place);
+                        tiles the board can't represent fall back to /ship/<id>. */}
+                    <ShipLeaderboard ref={shipLeaderboardRef} />
 
                     {/* Toolbar is always visible once the landing pane is mounted —
                      keeps the empty-state UX coherent when the Best list returns

--- a/client/app/components/RealmTopShipsTreemapSVG.tsx
+++ b/client/app/components/RealmTopShipsTreemapSVG.tsx
@@ -19,6 +19,7 @@ import { useRealm, useDisplayRealm } from '../context/RealmContext';
 import { buildShipPath } from '../lib/entityRoutes';
 import { formatSeasonLabel } from '../lib/shipSeason';
 import { trackEvent } from '../lib/umami';
+import { SHIP_TYPES, type ShipType, type Tier } from './ShipLeaderboard';
 
 interface TopShip {
     ship_id: number;
@@ -86,8 +87,20 @@ interface HoverState {
     y: number;
 }
 
-const RealmTopShipsTreemapSVG: React.FC = () => {
+interface RealmTopShipsTreemapSVGProps {
+    // When provided, clicking a tile whose tier+type the inline ShipLeaderboard
+    // can represent (T8/9/10 + a canonical type) drills there in place instead of
+    // navigating to /ship/<id>. Tiles outside that range keep the route fallback.
+    onSelect?: (sel: { id: number; name: string; tier: Tier; type: ShipType }) => void;
+}
+
+const RealmTopShipsTreemapSVG: React.FC<RealmTopShipsTreemapSVGProps> = ({ onSelect }) => {
     const { realm } = useRealm();
+    // Mirror the latest onSelect into a ref so the D3 click handler (bound inside
+    // the render effect below) reads the current callback without the render
+    // effect depending on it — avoids rebuilding the treemap when it changes.
+    const onSelectRef = useRef(onSelect);
+    useEffect(() => { onSelectRef.current = onSelect; });
     // Hydration-safe realm for the heading/aria-label rendered in the SSG shell
     // (the live `realm` drives fetches; this only feeds rendered text).
     const displayRealm = useDisplayRealm();
@@ -181,8 +194,20 @@ const RealmTopShipsTreemapSVG: React.FC = () => {
             .attr('stroke-width', 1)
             .style('cursor', 'pointer')
             .on('click', function onClick(this: SVGRectElement, _event: MouseEvent, d: { data: TopShip }) {
-                trackEvent('treemap-ship', { ship_id: d.data.ship_id, ship_name: d.data.ship_name, mode, realm });
-                router.push(buildShipPath(d.data.ship_id, d.data.ship_name, realm));
+                const { ship_id, ship_name, tier, ship_type } = d.data;
+                // The leaderboard only covers T8/9/10 + the five canonical types;
+                // anything else (sub-T8, null tier/type, unknown type) keeps the
+                // /ship/<id> route so no tile becomes a dead click.
+                const supported = !!onSelectRef.current
+                    && (tier === 8 || tier === 9 || tier === 10)
+                    && ship_type != null && (SHIP_TYPES as readonly string[]).includes(ship_type);
+                if (supported) {
+                    trackEvent('treemap-ship', { ship_id, ship_name, mode, realm, target: 'leaderboard' });
+                    onSelectRef.current!({ id: ship_id, name: ship_name, tier: tier as Tier, type: ship_type as ShipType });
+                } else {
+                    trackEvent('treemap-ship', { ship_id, ship_name, mode, realm, target: 'route' });
+                    router.push(buildShipPath(ship_id, ship_name, realm));
+                }
             })
             .on('mousemove', function onMove(this: SVGRectElement, event: MouseEvent, d: { data: TopShip }) {
                 const rect = containerRef.current?.getBoundingClientRect();

--- a/client/app/components/ShipLeaderboard.tsx
+++ b/client/app/components/ShipLeaderboard.tsx
@@ -21,6 +21,7 @@ import { shipClass } from '../lib/shipIdentity';
 import { buildPlayerPath } from '../lib/entityRoutes';
 import { trackEvent } from '../lib/umami';
 import wrColor from '../lib/wrColor';
+import SubmarineEasterEgg from './SubmarineEasterEgg';
 
 export type Tier = 8 | 9 | 10;
 // Raw `Ship.ship_type` strings the backend filters on (note: "AirCarrier", no
@@ -220,11 +221,16 @@ const ShipLeaderboard = forwardRef<ShipLeaderboardHandle>((_props, ref) => {
         trackEvent('ship-leaderboard-sort', { realm, scope, column, dir });
 
     const bothSelected = tier != null && type != null;
+    // The T9 + Submarine combo (World of Warships has no such ship) short-circuits
+    // to the easter egg and must issue NO fetch — the endpoint would 400 in any
+    // env where SHIP_BADGE_TIERS excludes 9 (e.g. local dev) and is pointless in
+    // prod. Gate both the fetch effect and the render branch on this predicate.
+    const isSubEasterEgg = tier === 9 && type === 'Submarine';
 
     // Ship list fetch (only with both filters set and no ship drilled into).
     const listReqId = useRef(0);
     useEffect(() => {
-        if (!bothSelected || selectedShip) return;
+        if (!bothSelected || selectedShip || isSubEasterEgg) return;
         const reqId = ++listReqId.current;
         setListLoading(true);
         setListError(false);
@@ -246,7 +252,7 @@ const ShipLeaderboard = forwardRef<ShipLeaderboardHandle>((_props, ref) => {
                 setListError(true);
                 setListLoading(false);
             });
-    }, [realm, tier, type, bothSelected, selectedShip]);
+    }, [realm, tier, type, bothSelected, selectedShip, isSubEasterEgg]);
 
     // Ship board fetch (drill-down) — reuses the existing /ship leaderboard.
     const boardReqId = useRef(0);
@@ -346,6 +352,8 @@ const ShipLeaderboard = forwardRef<ShipLeaderboardHandle>((_props, ref) => {
                     <p className="py-6 text-sm text-[var(--text-muted)]">
                         Pick a tier and a type to rank ships by win rate.
                     </p>
+                ) : isSubEasterEgg ? (
+                    <SubmarineEasterEgg />
                 ) : selectedShip ? (
                     <ShipBoard
                         realm={realm}

--- a/client/app/components/ShipLeaderboard.tsx
+++ b/client/app/components/ShipLeaderboard.tsx
@@ -11,7 +11,7 @@
 // and Clear returns to the list for the still-selected tier/type. No navigation,
 // no new full-page route.
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
@@ -22,12 +22,20 @@ import { buildPlayerPath } from '../lib/entityRoutes';
 import { trackEvent } from '../lib/umami';
 import wrColor from '../lib/wrColor';
 
-type Tier = 8 | 9 | 10;
+export type Tier = 8 | 9 | 10;
 // Raw `Ship.ship_type` strings the backend filters on (note: "AirCarrier", no
 // space). These are the `type` query-param values the new endpoint accepts.
-const SHIP_TYPES = ['Battleship', 'Cruiser', 'Destroyer', 'AirCarrier', 'Submarine'] as const;
-type ShipType = (typeof SHIP_TYPES)[number];
+export const SHIP_TYPES = ['Battleship', 'Cruiser', 'Destroyer', 'AirCarrier', 'Submarine'] as const;
+export type ShipType = (typeof SHIP_TYPES)[number];
 const TIERS: Tier[] = [8, 9, 10];
+
+// Imperative handle the landing treemap drives to drill straight into a ship's
+// player board in place (see runbook-treemap-shipleaderboard-handoff). Kept as a
+// command rather than lifted state so this component keeps owning its list/board
+// state and there is no prop↔state sync race after the user hits Clear.
+export interface ShipLeaderboardHandle {
+    selectShip(sel: { id: number; name: string; tier: Tier; type: ShipType }): void;
+}
 
 interface ListShip {
     ship_id: number;
@@ -172,8 +180,9 @@ const InfoHint: React.FC<{ text: string }> = ({ text }) => (
     </div>
 );
 
-const ShipLeaderboard: React.FC = () => {
+const ShipLeaderboard = forwardRef<ShipLeaderboardHandle>((_props, ref) => {
     const { realm } = useRealm();
+    const sectionRef = useRef<HTMLElement>(null);
 
     // Land on T10 Battleships so the board shows real standings immediately
     // (these buckets are pre-warmed daily — see warm_realm_top_ships_task).
@@ -269,17 +278,31 @@ const ShipLeaderboard: React.FC = () => {
 
     const openShip = (s: ListShip) => {
         setSelectedShip({ id: s.ship_id, name: s.ship_name });
-        trackEvent('ship-leaderboard-drilldown', { realm, ship_id: s.ship_id });
+        trackEvent('ship-leaderboard-drilldown', { realm, ship_id: s.ship_id, source: 'row' });
     };
     const clearShip = () => {
         setSelectedShip(null);
         trackEvent('ship-leaderboard-clear', { realm });
     };
 
+    // Imperative drill-down from the landing treemap: set tier+type+ship in one
+    // batched update (so the dormant list effect never fires for the new bucket)
+    // and scroll the board into view. tier/type are set directly rather than via
+    // chooseTier/chooseType so a later Clear lands on the right tier/type list.
+    useImperativeHandle(ref, () => ({
+        selectShip({ id, name, tier: t, type: ty }) {
+            setTier(t);
+            setType(ty);
+            setSelectedShip({ id, name });
+            trackEvent('ship-leaderboard-drilldown', { realm, ship_id: id, source: 'treemap' });
+            sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        },
+    }), [realm]);
+
     const typeLabel = useMemo(() => (type ? shipClass(type)?.label ?? type : null), [type]);
 
     return (
-        <section className="mt-2 pt-8" aria-label="Ship leaderboard">
+        <section ref={sectionRef} className="mt-2 pt-8" aria-label="Ship leaderboard">
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                 <h3 className={HEADING_CLASS}>Ships</h3>
                 <div className="flex flex-wrap items-center gap-2">
@@ -346,7 +369,9 @@ const ShipLeaderboard: React.FC = () => {
             </div>
         </section>
     );
-};
+});
+
+ShipLeaderboard.displayName = 'ShipLeaderboard';
 
 const SHIP_NAME_LINK =
     'text-left font-medium text-[var(--accent-mid)] transition-colors hover:text-[var(--accent-dark)] hover:underline';

--- a/client/app/components/SubmarineEasterEgg.tsx
+++ b/client/app/components/SubmarineEasterEgg.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+import { useTheme } from '../context/ThemeContext';
+import { chartColors } from '../lib/chartTheme';
+
+const SUB_ART = [
+    '         |\\_',
+    '   _____|~ |____',
+    '  (  --         ~~~~--_,',
+    "   ~~~~~~~~~~~~~~~~~~~'`",
+];
+
+const WIDTH = 900;
+const HEIGHT = 300;
+const FONT_SIZE = 18;
+const LINE_H = 22;
+const CROSS_MS = 12000;
+// Fixed off-screen bounds (no getBBox). At ~0.6em/char monospace, the widest
+// line (~23 chars) is ~250px; -360 → WIDTH+60 fully clears both edges.
+const X_START = -360;
+const X_END = WIDTH + 60;
+const BLOCK_H = SUB_ART.length * LINE_H;
+const Y_MID = (HEIGHT - BLOCK_H) / 2;
+
+const SubmarineEasterEgg: React.FC = () => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const { theme } = useTheme();
+
+    useEffect(() => {
+        const host = ref.current;
+        if (!host) return;
+        const colors = chartColors[theme];
+
+        d3.select(host).selectAll('*').remove();
+
+        const svg = d3
+            .select(host)
+            .append('svg')
+            .attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`)
+            .attr('width', '100%')
+            .attr('role', 'img')
+            .attr('aria-label', 'There are no Tier 9 submarines — but here is one anyway.')
+            .style('display', 'block')
+            .style('max-width', `${WIDTH}px`)
+            .style('background', 'transparent');
+
+        const g = svg.append('g');
+        const text = g
+            .append('text')
+            .attr('font-family', 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace')
+            .attr('font-size', FONT_SIZE)
+            .attr('fill', colors.shipSS)
+            .style('white-space', 'pre');
+
+        SUB_ART.forEach((line, i) => {
+            text
+                .append('tspan')
+                .attr('x', 0)
+                .attr('y', i * LINE_H + FONT_SIZE)
+                .attr('xml:space', 'preserve')
+                .text(line);
+        });
+
+        const reduce =
+            typeof window !== 'undefined' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        if (reduce) {
+            // Static, roughly centered (no animation).
+            g.attr('transform', `translate(${(WIDTH - 250) / 2}, ${Y_MID})`);
+            return () => {
+                d3.select(host).selectAll('*').remove();
+            };
+        }
+
+        let stopped = false;
+        const swim = () => {
+            if (stopped) return;
+            g.attr('transform', `translate(${X_START}, ${Y_MID})`)
+                .transition()
+                .duration(CROSS_MS)
+                .ease(d3.easeLinear)
+                .attrTween('transform', () => {
+                    const ix = d3.interpolateNumber(X_START, X_END);
+                    return (t: number) => {
+                        const x = ix(t);
+                        const bob = Math.sin(t * Math.PI * 4) * 8; // gentle vertical bob
+                        return `translate(${x}, ${Y_MID + bob})`;
+                    };
+                })
+                .on('end', swim);
+        };
+        swim();
+
+        return () => {
+            stopped = true;
+            d3.select(host).selectAll('*').interrupt();
+            d3.select(host).selectAll('*').remove();
+        };
+    }, [theme]);
+
+    return <div ref={ref} className="w-full" style={{ maxWidth: WIDTH }} />;
+};
+
+export default SubmarineEasterEgg;

--- a/client/app/components/__tests__/ShipLeaderboard.test.tsx
+++ b/client/app/components/__tests__/ShipLeaderboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import ShipLeaderboard from '../ShipLeaderboard';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import ShipLeaderboard, { type ShipLeaderboardHandle } from '../ShipLeaderboard';
 import { fetchSharedJson } from '../../lib/sharedJsonFetch';
 import { trackEvent } from '../../lib/umami';
 
@@ -49,6 +49,8 @@ describe('ShipLeaderboard', () => {
         mockFetch.mockReset();
         mockFetch.mockImplementation((url: string) => routeFetch(url));
         mockTrack.mockClear();
+        // jsdom has no scrollIntoView; the imperative handle calls it.
+        Element.prototype.scrollIntoView = jest.fn();
     });
 
     const selectTierAndType = (typeAbbr = 'DD') => {
@@ -146,6 +148,60 @@ describe('ShipLeaderboard', () => {
         fireEvent.click(screen.getByRole('button', { name: 'BB' }));
         await screen.findAllByText('Gearing');
         expect(screen.queryByText('UsunU')).not.toBeInTheDocument();
+    });
+
+    describe('treemap handoff (selectShip handle)', () => {
+        it('drills straight to a ship board, scrolls, and sets the underlying filters', async () => {
+            const ref = React.createRef<ShipLeaderboardHandle>();
+            render(<ShipLeaderboard ref={ref} />);
+            // Let the default T10/BB list settle, then clear the call log so the
+            // assertions below only see fetches caused by the handle.
+            await screen.findAllByText('Gearing');
+            mockFetch.mockClear();
+
+            act(() => {
+                ref.current!.selectShip({ id: 111, name: 'Shimakaze', tier: 10, type: 'Destroyer' });
+            });
+
+            // (a) Board endpoint fetched and the player board renders...
+            await screen.findAllByText('UsunU');
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/realm/na/ship/111/leaderboard',
+                expect.objectContaining({ cacheKey: 'ship-lb:na:111' }),
+            );
+            // (b) ...without needing the ship-list endpoint to reach the board.
+            expect(mockFetch).not.toHaveBeenCalledWith(
+                expect.stringContaining('/ships?'),
+                expect.anything(),
+            );
+            // (c) The section was scrolled into view.
+            expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+            // (d) Clear returns to the T10 Destroyer list — proves tier+type were set.
+            fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+            await waitFor(() => {
+                expect(mockFetch).toHaveBeenCalledWith(
+                    '/api/realm/na/ships?tier=10&type=Destroyer',
+                    expect.objectContaining({ cacheKey: 'ships-by:na:10:Destroyer' }),
+                );
+            });
+            expect(screen.getByRole('button', { name: '10' })).toHaveAttribute('aria-pressed', 'true');
+            expect(screen.getByRole('button', { name: 'DD' })).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        it('tags the drill-down event with source=treemap', async () => {
+            const ref = React.createRef<ShipLeaderboardHandle>();
+            render(<ShipLeaderboard ref={ref} />);
+            await screen.findAllByText('Gearing');
+
+            act(() => {
+                ref.current!.selectShip({ id: 111, name: 'Shimakaze', tier: 10, type: 'Destroyer' });
+            });
+            expect(mockTrack).toHaveBeenCalledWith(
+                'ship-leaderboard-drilldown',
+                expect.objectContaining({ realm: 'na', ship_id: 111, source: 'treemap' }),
+            );
+        });
     });
 
     describe('umami tracking', () => {

--- a/client/app/components/__tests__/ShipLeaderboard.test.tsx
+++ b/client/app/components/__tests__/ShipLeaderboard.test.tsx
@@ -8,6 +8,17 @@ jest.mock('../../lib/sharedJsonFetch', () => ({
     fetchSharedJson: jest.fn(),
 }));
 
+// The real SubmarineEasterEgg runs a D3 animation effect that calls
+// window.matchMedia (unimplemented in jsdom) and schedules transition rAF
+// loops — neither is meaningful under Jest. Stub it to a container that
+// exposes the same aria-label so the wiring/branch assertions can find it.
+jest.mock('../SubmarineEasterEgg', () => ({
+    __esModule: true,
+    default: () => (
+        <div aria-label="There are no Tier 9 submarines — but here is one anyway." />
+    ),
+}));
+
 jest.mock('../../context/RealmContext', () => ({
     useRealm: () => ({ realm: 'na' }),
 }));
@@ -201,6 +212,33 @@ describe('ShipLeaderboard', () => {
                 'ship-leaderboard-drilldown',
                 expect.objectContaining({ realm: 'na', ship_id: 111, source: 'treemap' }),
             );
+        });
+    });
+
+    describe('T9 submarine easter egg', () => {
+        const T9_SUB_LABEL = 'There are no Tier 9 submarines — but here is one anyway.';
+
+        it('renders the easter egg for T9 + Submarine with NO fetch and no dead-end message', async () => {
+            render(<ShipLeaderboard />);
+            // Let the default T10/BB list settle, then clear the call log so the
+            // assertions below only see fetches caused by selecting T9 + SS.
+            await screen.findAllByText('Gearing');
+            mockFetch.mockClear();
+
+            fireEvent.click(screen.getByRole('button', { name: '9' }));
+            fireEvent.click(screen.getByRole('button', { name: 'SS' }));
+
+            // (a) The easter-egg container renders (query by its aria-label).
+            await screen.findByLabelText(T9_SUB_LABEL);
+            // (b) The dead-end "No ranked ships" message is absent.
+            expect(screen.queryByText(/no ranked ships/i)).not.toBeInTheDocument();
+            // (c) The short-circuit fired no T9+Submarine ships fetch.
+            await waitFor(() => {
+                expect(mockFetch).not.toHaveBeenCalledWith(
+                    expect.stringContaining('tier=9&type=Submarine'),
+                    expect.anything(),
+                );
+            });
         });
     });
 


### PR DESCRIPTION
Two independent landing-page features, each its own commit.

## 1. Treemap → inline ShipLeaderboard handoff (`ef54ad6`)
Clicking a tile in the realm most-played-ships treemap now sets the inline `ShipLeaderboard`'s tier+type to that ship and opens its best-player board **in place** (scrolling it into view) instead of navigating to `/ship/<id>`.

- Bridged by a one-shot imperative handle (`ShipLeaderboardHandle.selectShip`) through the shared `PlayerSearch` parent — the leaderboard's internal list/board state stays encapsulated.
- Treemap reads the callback via a ref, so the D3 render effect is not rebuilt when it changes.
- **`/ship/<id>` route unchanged** and remains the fallback for tiles the leaderboard can't represent (sub-T8, null tier, unknown type).
- Analytics: `treemap-ship` gains `target=leaderboard|route`; `ship-leaderboard-drilldown` gains `source=treemap|row`.

## 2. T9-submarine easter egg (`eaa2f4b`)
Picking **Tier 9 + Submarine** (a combination World of Warships has no ship for) now renders a theme-aware D3 ASCII submarine cruising across the leaderboard, via a **parent short-circuit that issues no fetch**, instead of a dead-end "No ranked ships" message.

- New self-contained `SubmarineEasterEgg.tsx` (D3, 900×300, transparent bg, `colors.shipSS`, left→right loop + bob, honors `prefers-reduced-motion`, cleans up on unmount/theme change).
- Note: the fetch lives in a separate `useEffect`, so the short-circuit gates **both** the fetch effect and the render branch via `isSubEasterEgg` — the "no API call" guarantee genuinely holds (also avoids a 400 in local dev where `SHIP_BADGE_TIERS` excludes T9).
- Runbook marked IMPLEMENTED + registered in `doc_registry.json`.

## Verification (final merged tree)
- `tsc --noEmit` — only the 15 pre-existing unrelated errors; none in changed files
- `eslint` — clean
- `npm test` — 214/214 across 33 suites (incl. both new tests)
- `npm run build` — compiled successfully

Frontend-only; no backend/API/model changes. Both are `feat:` (minor) — a release bump + client rebuild is needed at ship time (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)