### PR TITLE
perf(clan-members): cut per-poll cost on the hydration loop

### DIFF
--- a/server/warships/tests/test_views.py
+++ b/server/warships/tests/test_views.py
@@ -4806,3 +4806,81 @@ class PlayerLiveRefreshSignalTests(TestCase):
         self.assertIsNotNone(get_cached_player_detail(77004, realm="na"))
         invalidate_player_detail_cache(77004, realm="na")
         self.assertIsNone(get_cached_player_detail(77004, realm="na"))
+
+
+class RecordClanLookupDebounceTests(TestCase):
+    """`_record_clan_lookup` runs on every clan read (incl. each hydration poll
+    and each response-cache hit), so it must not write + bust the landing cache
+    unless `last_lookup` has actually gone stale past the debounce interval."""
+
+    def setUp(self):
+        cache.clear()
+
+    @patch("warships.views.invalidate_landing_clan_caches")
+    def test_records_when_never_looked_up(self, mock_invalidate):
+        from warships.views import _record_clan_lookup
+        clan = Clan.objects.create(
+            clan_id=9701, name="NeverLookedUp", members_count=1,
+            last_fetch=timezone.now(), last_lookup=None)
+        _record_clan_lookup(clan, realm="na")
+        mock_invalidate.assert_called_once()
+        self.assertIsNotNone(clan.last_lookup)
+
+    @patch("warships.views.invalidate_landing_clan_caches")
+    def test_skips_within_interval(self, mock_invalidate):
+        from warships.views import _record_clan_lookup
+        now = timezone.now()
+        clan = Clan.objects.create(
+            clan_id=9702, name="RecentlyLookedUp", members_count=1,
+            last_fetch=now, last_lookup=now)
+        _record_clan_lookup(clan, realm="na")
+        # Within the debounce window: no landing-cache bust, no write.
+        mock_invalidate.assert_not_called()
+        self.assertEqual(clan.last_lookup, now)
+
+    @patch("warships.views.invalidate_landing_clan_caches")
+    def test_records_again_once_stale(self, mock_invalidate):
+        from warships.views import _record_clan_lookup, CLAN_LOOKUP_RECORD_INTERVAL
+        stale = timezone.now() - CLAN_LOOKUP_RECORD_INTERVAL - timedelta(minutes=1)
+        clan = Clan.objects.create(
+            clan_id=9703, name="StaleLookup", members_count=1,
+            last_fetch=timezone.now(), last_lookup=stale)
+        _record_clan_lookup(clan, realm="na")
+        mock_invalidate.assert_called_once()
+        self.assertGreater(clan.last_lookup, stale)
+        # An immediate repeat is now debounced.
+        mock_invalidate.reset_mock()
+        _record_clan_lookup(clan, realm="na")
+        mock_invalidate.assert_not_called()
+
+
+class ClanMemberBadgesCacheTests(TestCase):
+    """Badges are recomputed only nightly, so the hydration poll loop must not
+    re-run the 3-query bulk fetch on every poll — `_clan_member_badges_cached`
+    caches per clan, keyed on the member-pk set so a roster change rotates it."""
+
+    def setUp(self):
+        cache.clear()
+
+    @patch("warships.data.get_players_ship_badges_bulk")
+    def test_cached_across_calls_same_roster(self, mock_bulk):
+        from warships.views import _clan_member_badges_cached
+        mock_bulk.return_value = {101: [{"ship_id": 1, "rank": 1}]}
+
+        first = _clan_member_badges_cached("4242", "na", [101, 102, 103])
+        second = _clan_member_badges_cached("4242", "na", [103, 101, 102])  # reordered
+
+        # Underlying bulk fetch ran once; the second (poll) call hit cache.
+        mock_bulk.assert_called_once()
+        self.assertEqual(first, second)
+
+    @patch("warships.data.get_players_ship_badges_bulk")
+    def test_roster_change_rotates_key(self, mock_bulk):
+        from warships.views import _clan_member_badges_cached
+        mock_bulk.return_value = {}
+
+        _clan_member_badges_cached("4242", "na", [101, 102])
+        _clan_member_badges_cached("4242", "na", [101, 102, 104])  # new member joined
+
+        # Different roster -> different cache key -> recompute.
+        self.assertEqual(mock_bulk.call_count, 2)

--- a/server/warships/views.py
+++ b/server/warships/views.py
@@ -136,10 +136,53 @@ def _set_player_refresh_headers(response, pending: bool, next_refresh_epoch: int
     response['X-Player-Next-Refresh'] = str(next_refresh_epoch)
 
 
+# `last_lookup` only feeds the soft "recently-viewed" landing-clan ranking, so
+# it does not need second-level precision. Debounce it: this runs on every clan
+# read — including every clan-members hydration poll (up to 12/view) and every
+# response-cache hit (it sits before the cache check in clan_members) — so
+# writing + busting the landing cache unconditionally added a DB write and a
+# landing republish-dispatch per request. Recording at most once per interval
+# collapses a 12-poll view to a single write+invalidation (zero if looked up
+# recently) while preserving the ranking signal.
+CLAN_LOOKUP_RECORD_INTERVAL = timedelta(minutes=10)
+
+
 def _record_clan_lookup(clan: Clan, realm: str = DEFAULT_REALM) -> None:
-    clan.last_lookup = timezone.now()
+    now = timezone.now()
+    if clan.last_lookup and (now - clan.last_lookup) < CLAN_LOOKUP_RECORD_INTERVAL:
+        return
+    clan.last_lookup = now
     clan.save(update_fields=["last_lookup"])
     invalidate_landing_clan_caches(realm=realm)
+
+
+# Top-spot ship badges are recomputed only nightly (ShipTopPlayerSnapshot), so
+# they are a static invariant relative to the clan-members hydration poll loop
+# (up to 12 polls/view, each otherwise re-running the 3-query bulk fetch + CPU).
+# Cache them per clan so the loop — and concurrent viewers of the same clan —
+# share one computation. Keyed on a hash of the sorted member PKs so a roster
+# change rotates the key naturally (a new member otherwise shows no badge until
+# expiry). NOTE: this only ever fires on the hydration-pending path; a fully
+# hydrated clan short-circuits on the full-response cache before badges are
+# computed. The member query itself stays live each poll because it carries the
+# ranked/efficiency columns being hydrated — caching those would display a
+# member's pre-hydration value the moment polling stops.
+CLAN_MEMBER_BADGES_CACHE_TTL = 300  # 5 min — spans the poll loop + cross-view sharing
+
+
+def _clan_member_badges_cached(clan_id: str, realm: str, member_pks: list) -> dict:
+    from warships.data import get_players_ship_badges_bulk
+    pk_signature = sha256(
+        ','.join(str(pk) for pk in sorted(member_pks)).encode()
+    ).hexdigest()[:16]
+    cache_key = realm_cache_key(
+        realm, f'clan:member-badges:v1:{clan_id}:{pk_signature}')
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+    badges = get_players_ship_badges_bulk(member_pks, realm=realm)
+    cache.set(cache_key, badges, CLAN_MEMBER_BADGES_CACHE_TTL)
+    return badges
 
 
 PUBLIC_API_THROTTLES = [AnonRateThrottle, UserRateThrottle]
@@ -1661,7 +1704,7 @@ def clan_members(request, clan_id: str) -> Response:
 
     _record_clan_lookup(clan, realm=realm)
 
-    from warships.data import queue_clan_efficiency_hydration, queue_clan_ranked_hydration, clan_battle_summary_is_stale, maybe_refresh_clan_battle_data, CLAN_BATTLE_PLAYER_HYDRATION_MAX_IN_FLIGHT, get_players_ship_badges_bulk
+    from warships.data import queue_clan_efficiency_hydration, queue_clan_ranked_hydration, clan_battle_summary_is_stale, maybe_refresh_clan_battle_data, CLAN_BATTLE_PLAYER_HYDRATION_MAX_IN_FLIGHT
     local_member_count = clan.player_set.exclude(name='').count()
     needs_clan_refresh = (
         not clan.members_count
@@ -1731,8 +1774,9 @@ def clan_members(request, clan_id: str) -> Response:
             return None
         return max(0, (today - member.last_battle_date).days)
 
-    # Current top-spot ship badges for every member in two queries (avoids N+1).
-    member_badges = get_players_ship_badges_bulk([m.pk for m in members], realm=realm)
+    # Current top-spot ship badges for every member — cached per clan so the
+    # hydration poll loop doesn't re-run the bulk fetch on every poll.
+    member_badges = _clan_member_badges_cached(clan_id, realm, [m.pk for m in members])
 
     member_rows = []
     for member in members:


### PR DESCRIPTION
## Summary

The clan-members endpoint is re-fetched by the client **up to 12× per view** while ranked/efficiency hydration is pending (a pending response can't be cached). This PR trims what each of those polls costs the server. It does **not** reduce the request count (that's a separate client-side / throttle lever), so it targets aggregate per-request load on the 2-vCPU / 5-sync-worker box — not the per-IP throttle.

Surfaced while load-testing player-page refresh: ~4 concurrent synthetic visits (sharing the operator's IP with a live browser) made the clan member list break — root cause was the per-IP `120/min` throttle, but the investigation exposed this endpoint as the most load-sensitive surface.

### Tier 1 — debounce `_record_clan_lookup`
It ran on **every** clan read — including every hydration poll and every response-cache hit, since it sits *before* the cache check — doing a DB write **+ a landing-clan-cache invalidation** (Redis dirty-mark + Celery republish dispatch) each time. Now it records at most once per 10 min per clan: a 12-poll view collapses to a single write + invalidation (zero if looked up recently). Fixes all 5 call sites.

### Tier 2 — cache the ship-badges bulk fetch per clan
Badges are recomputed only nightly (`ShipTopPlayerSnapshot`), so they're a static invariant relative to the poll loop. The 3-query bulk fetch + CPU no longer reruns on every poll and is shared across concurrent viewers. Keyed on a hash of the sorted member PKs so a roster change rotates the key. Only fires on the pending path (fully-hydrated clans short-circuit on the response cache).

**Deliberately left live:** the member query stays per-poll because it carries the `ranked`/`efficiency` columns *being hydrated* — caching those would display a member's pre-hydration value the moment polling stops (a real display regression).

### Net effect
Removes ~3 of ~6 SELECTs + badge CPU per poll, plus the per-poll write/invalidation. The member query, pending-flag Redis GETs, and dispatch remain per poll — irreducible without trading bounded display-lag (offered separately, not included here).

## Tests
- `RecordClanLookupDebounceTests` — records when never looked up; skips within the interval (no write, no invalidation); re-records once stale.
- `ClanMemberBadgesCacheTests` — same-roster calls hit cache (bulk fetch runs once); roster change rotates the key.
- Full `test_views.py`: **144 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)