### PR TITLE
fix(seo) + feat(ship-leaderboard): sitemap hidden-player exclusion + realm top-ships/hot-players pass

### DIFF
--- a/agents/runbooks/runbook-hot-players-engagement-queue-2026-06-10.md
+++ b/agents/runbooks/runbook-hot-players-engagement-queue-2026-06-10.md
@@ -193,6 +193,35 @@ for player in HotPlayer(realm):
   short-circuits `skipped/wg-fetch-failed-or-hidden`; we record the skip and move on (no
   retry storm).
 
+#### Work-budgeted rotation (2026-06-15) — required for a floor-missed seed
+
+The skip-if-fresh pseudocode above is cheap **only when most of the set is floor-fresh**
+(the original most-active seed). When the backfill seed is changed to **floor-missed**
+players (`backfill_hot_players` excludes anyone with a `BattleObservation` within
+`HOT_OBSERVE_FLOOR_HOURS`), *every* member is an expensive pull, and an unbudgeted
+`-hot_score` sweep blows the task's **540s soft limit at ~90 members** and re-pulls the
+same static head every run while the tail starves (incident 2026-06-15; see
+`project_hot_queue_stale_seed_starves` memory). `capture_hot_players` therefore:
+
+- **Orders** engagement/pinned first (by `-hot_score`, preserving their daily contract —
+  few, high-value), then backfill by **`last_observed_at` ASC NULLS FIRST** so the
+  floor-missed set drains **round-robin by coverage age**.
+- **Stops after `HOT_CAPTURE_MAX_PULLS` WG fetches** (success *or* hidden-skip — both
+  spend a call); members past the budget rotate in on the next run. The budget is a
+  **count, not wall-clock** (deterministic, unit-tested) and sized to stay under 540s even
+  at the worst ~7s/pull (`65 × 7 = 455s`).
+- **Stamps `last_observed_at`** on any spent WG call (advancing the member to the back of
+  the rotation). A cheap fresh-skip spends no call and is *not* stamped — it stays at the
+  head for a free re-check next run (self-correcting, no budget burn).
+- Result dict exposes `wg_calls` / `stopped_early` / `remaining` for the
+  `/observation`-style ops read and the self-chain trigger.
+
+**Drain rate:** one scheduled run/day × `HOT_CAPTURE_MAX_PULLS=65` ⇒ a full `HOT_PLAYERS_MAX=800`
+floor-missed set cycles in **~12 days**. A bounded **self-chain** (re-enqueue while
+`stopped_early` and pull-work remains, capped depth) is the planned follow-up to tighten
+this to ~2 days, at the cost of ~`800×~6s`≈80 min/realm/day of pulls competing with the
+floor on the shared `background` pool — **not yet shipped**; ship rotation+budget first.
+
 ### Scheduling — per-realm striped, `signals.py`
 
 Register both tasks in the `@receiver(post_migrate)` block using
@@ -240,6 +269,7 @@ the snapshot/enrichment-maintenance families (still respects `HOT_PLAYERS_ENABLE
 | `HOT_PLAYERS_MAX` | `500` (prod `800` since 2026-06-15) | Per-realm cap on hot-set size (bounds WG cost). |
 | `HOT_OBSERVE_FLOOR_HOURS` | `20` | Skip-if-fresh: skip observation if one is newer than this. |
 | `HOT_PLAYERS_CAPTURE_DELAY` | `0.5` | WG pacing between hot captures (crawl-coexist value). |
+| `HOT_CAPTURE_MAX_PULLS` | `65` | Max WG fetches per capture run — anti-starvation work budget (count, stays <540s soft limit at ~7s/pull). Members past it rotate in next run. |
 
 ## Observability
 

--- a/agents/runbooks/runbook-leaderboard-updates.md
+++ b/agents/runbooks/runbook-leaderboard-updates.md
@@ -1,43 +1,45 @@
 # Runbook: Ship Leaderboard Data Freshness & Update Cadence
 
-_Last updated: 2026-06-11_
+_Last updated: 2026-06-15_
 
 _Status: Active operational reference_
 
-_Context: Captures how "live" the ship leaderboard data actually is — the full freshness chain from the `ShipLeaderboard` / `ShipRouteView` components down to the snapshot writer — so future operators don't misread the standings as real-time._
+_Context: Captures how "live" the ship leaderboard data actually is — the full freshness chain from the `ShipLeaderboard` / `ShipRouteView` / `RealmTopShipsTreemapSVG` components down to the snapshot writer — so future operators don't misread the standings as real-time._
+
+> **Cadence updated 2026-06-14/15 — now a NIGHTLY ROLLING recompute, not a fortnightly season.** Earlier revisions of this runbook described a fixed 2-week season boundary; that model is gone. The `/ship/<id>` board + profile badges moved to a rolling trailing 14-day recompute on 2026-06-14 ([runbook-ship-badges-rolling-2026-06-14.md](runbook-ship-badges-rolling-2026-06-14.md)), and the landing treemap + tier/type drill-down list followed on 2026-06-15 so all three share one rolling window 1:1.
 
 ## Purpose
 
-Answer the recurring question: **how live are the ship stats shown on `/ship/<id>` and the landing tier/type drill-down board?** The short answer is **not live** — they are a precomputed **fortnightly batch snapshot**, not a real-time query. This runbook documents the dominant cadence (the 2-week season boundary), the two 15-minute caches layered on top, the kill switch that gates the writer, and how to confirm the current state in prod.
+Answer the recurring question: **how live are the ship stats shown on `/ship/<id>`, the landing tier/type drill-down board, and the realm treemap?** The short answer is **not live, but daily** — they are a precomputed snapshot recomputed **every night** over a **rolling trailing 14-day window**, not a real-time query. This runbook documents the dominant cadence (the nightly snapshot), the 15-minute caches layered on top, the kill switch that gates the writer, and how to confirm the current state in prod.
 
-Read this before "fixing" a leaderboard that looks stale — within a season, static is **expected**, not a bug.
+Read this before "fixing" a leaderboard that looks stale — within a day, static is **expected**, not a bug.
 
 ## Freshness chain (dominant factor first)
 
-### 1. The real cadence — once every 2 weeks at a season boundary
+### 1. The real cadence — once a night
 
-The read path does **no live aggregation**. `get_ship_leaderboard()` (`server/warships/data.py`) does a pure snapshot read of the most recent `captured_on`'s `ShipTopPlayerSnapshot` rows for the ship+realm, joins `Ship` for the header, and shapes the payload. The endpoint is `ship_leaderboard` (`server/warships/views.py:2136`).
+The read path does **no live aggregation**. `get_ship_leaderboard()` (`server/warships/data.py`) does a pure snapshot read of the most recent `captured_on`'s `ShipTopPlayerSnapshot` rows for the ship+realm, joins `Ship` for the header, and shapes the payload. The endpoint is `ship_leaderboard` (`server/warships/views.py`).
 
-Those snapshot rows are written by `snapshot_ship_top_players_task` (`server/warships/tasks.py:898`):
+Those snapshot rows are written by `snapshot_ship_top_players_task` (`server/warships/tasks.py`):
 
-- Runs on a **weekly Monday** Beat tick, but **self-gates on `is_season_boundary()`** (`data.py`, `delta % SHIP_SEASON_LENGTH_DAYS == 0`). So it is effectively **bi-weekly** — only the Monday a 14-day season closes — and it finalizes that *just-completed* season exactly once.
-- `SHIP_SEASON_LENGTH_DAYS = SHIP_LEADERBOARD_WINDOW_DAYS = 14` (`data.py:5855`, `:5872`).
-- The displayed board is the latest `captured_on` (a **season-start** date); its window is `[captured_on, captured_on + 14d)`. `next_window_open` (the in-progress season's close) is the authoritative value the frontend countdown reads.
+- Runs **nightly** per realm (Beat `ship-top-player-snapshot-{realm}`, striped by `REALM_CRAWL_CRON_HOURS`, ~02:30 + realm offset UTC). Each run recomputes the whole trailing window and overwrites that night's rows — there is no season boundary and no "finalize once" gate.
+- `SHIP_LEADERBOARD_WINDOW_DAYS = 14` (`data.py`) is the lookback span (operator-tunable). The fixed `SHIP_SEASON_*` epoch/length and `is_season_boundary()` are gone.
+- The displayed board is the latest `captured_on` (a **run date**); its window is `[captured_on - 14d, captured_on)`. Badges are worn **only while held** — a player who drops out of the top 3 loses the badge on the next nightly run.
 
-**Implication:** within a season the numbers are **completely static**. A player grinding the ship *today* will not appear/update until the season closes and the next snapshot recomputes. The displayed stats (`win_rate`, `battles`, `avg_damage`, `kills_per_battle`) are delta-sums over the closed 14-day window — the same basis as the profile ship badges. (Survival% / KDR are intentionally omitted: per-battle survival isn't available for a multi-battle window, so it would undercount.)
+**Implication:** the numbers advance **every day**. A trailing 14-day window shares ~93% of its data night to night, so turnover is gradual (a few ships/night), not churn — but it is no longer static. The displayed stats (`win_rate`, `battles`, `avg_damage`, `kills_per_battle`) are delta-sums over the trailing 14-day window — the same basis as the profile ship badges. (Survival% / KDR are intentionally omitted: per-battle survival isn't available for a multi-battle window, so it would undercount.)
 
-### 2. Two 15-minute caches on top (negligible vs the fortnight)
+### 2. 15-minute caches on top (negligible vs the nightly recompute)
 
-These only matter for the few minutes right after a new season snapshot lands; against a 2-week refresh they are noise.
+These only matter for the few minutes right after a new nightly snapshot lands; against a daily refresh they are noise.
 
-- **Backend Redis read-cache** — `SHIP_LEADERBOARD_CACHE_TTL = 900s` (`data.py:5856`), applied in the view (`cache_key = f"{realm}:ship-lb:{ship_id}"`, `views.py:2156`).
+- **Backend Redis read-cache** — `SHIP_LEADERBOARD_CACHE_TTL = 900s` (`data.py`), applied in the view (`cache_key = f"{realm}:ship-lb:{ship_id}"`).
 - **Client fetch cache** — `BOARD_FETCH_TTL_MS = 900_000` in `client/app/components/ShipLeaderboard.tsx`; the same 15 min as `SHIP_LEADERBOARD_FETCH_TTL_MS` in `client/app/components/ShipRouteView.tsx`. Both fetch via `fetchSharedJson`. Column **sorting is client-side** over the already-fetched rows — sorting never refetches.
 
 Note: `ShipLeaderboard.tsx` (landing tier/type drill-down) and `ShipRouteView.tsx` (the `/ship/<id>` page) hit the **same** `/api/realm/<realm>/ship/<ship_id>/leaderboard` endpoint, so the freshness story is identical for both.
 
 ### 3. Kill switch gating the writer
 
-`SHIP_BADGE_SNAPSHOT_ENABLED` (default `0`) gates `snapshot_ship_top_players_task`. If `0`, **no new snapshots are written** and the board freezes at the last-written season indefinitely. Prod is `=1` (verified 2026-06-11); tiers pinned `SHIP_BADGE_TIERS=8,9,10`.
+`SHIP_BADGE_SNAPSHOT_ENABLED` (default `0`) gates `snapshot_ship_top_players_task`. If `0`, **no new snapshots are written** and the board freezes at the last-written night indefinitely. Prod is `=1`; tiers pinned `SHIP_BADGE_TIERS=8,9,10`.
 
 ## Verify current state in prod
 
@@ -45,7 +47,7 @@ Note: `ShipLeaderboard.tsx` (landing tier/type drill-down) and `ShipRouteView.ts
 # Writer enabled? Which tiers?
 ssh root@battlestats.online 'grep -E "SHIP_BADGE_SNAPSHOT_ENABLED|SHIP_BADGE_TIERS" /etc/battlestats-server.env'
 
-# What season is currently published, and how many rows?
+# What night is currently published, and how many rows?
 ssh root@battlestats.online 'cd /opt/battlestats-server/current/server;
   set -a; . /etc/battlestats-server.env; . /etc/battlestats-server.secrets.env; set +a;
   /opt/battlestats-server/venv/bin/python manage.py shell -c "
@@ -55,37 +57,39 @@ print(\"rows total:\", S.objects.count())
 "'
 ```
 
-**Reference reading (2026-06-11):** single distinct `captured_on = 2026-05-25` (season `05-25 → 06-08`, finalized at the 06-08 boundary), `6135` rows. The board has been frozen since ~06-08 and next drops **2026-06-22**. Older seasons are pruned — `ShipTopPlayerSnapshot` is ephemeral, so seeing only one (or a couple of) `captured_on` values is normal.
+**Expected:** the newest `captured_on` should be **today (or yesterday)** per realm, with a few nights of history retained (`SHIP_BADGE_RETENTION_DAYS`, default 5) before pruning. If the newest `captured_on` is several days old, the nightly writer isn't firing — investigate the `background` worker / Beat, not the read path.
 
-## The landing tier/type list is a *different*, live path (switch-lag source)
+## The landing tier/type list + treemap share the rolling window (1:1 with the board)
 
-The freshness story above is the snapshot **board** read (`/ship/<id>/leaderboard`). The landing drill-down (`ShipLeaderboard.tsx`) layers a second surface on top with a very different cost profile:
+The freshness story above is the snapshot **board** read (`/ship/<id>/leaderboard`). The landing page layers two more surfaces, both now aggregating over the **same rolling window** the board reads:
 
-- **Click a ship** → `/ship/<id>/leaderboard` → `get_ship_leaderboard` → cheap `ShipTopPlayerSnapshot` row read, Redis-cached 15 min. Fast.
-- **Change a tier/type pill** → `/api/realm/<realm>/ships?tier=&type=` → `compute_realm_ships_by_tier_type` (`data.py:6553`) → a **live `BattleEvent` GROUP-BY** (`Sum` of battles/wins/damage/frags over the 14-day window, joined to `Player` for the realm). Expensive.
+- **Treemap** (`RealmTopShipsTreemapSVG.tsx`) → `/api/realm/<realm>/top-ships` → `compute_realm_top_ships` (`data.py`) — most-played ships, a `BattleEvent` GROUP-BY over the trailing window.
+- **Tier/type pill** (`ShipLeaderboard.tsx`) → `/api/realm/<realm>/ships?tier=&type=` → `compute_realm_ships_by_tier_type` (`data.py`) — a `BattleEvent` GROUP-BY (`Sum` of battles/wins/damage/frags over the window, joined to `Player` for the realm), candidate set restricted to ships ranked in the latest snapshot.
+- **Drill in** (click a ship) → `/ship/<id>/leaderboard` → `get_ship_leaderboard` → cheap `ShipTopPlayerSnapshot` row read, Redis-cached 15 min. Fast.
 
-This asymmetry is why **switching tier/type lags but drilling in is instant.** The list result is cached per `(realm, tier, type)` bucket under a season-tagged key (immutable for the whole season) — but there are **3 tiers × 5 types = 15 buckets per realm**, so before warming, the *first* click of any new combination paid the full cold aggregation on the request path (subsequent clicks of the same combo were warm). Redis `allkeys-lru` eviction could also re-cold a bucket mid-season.
+Both GROUP-BY surfaces resolve their window via `latest_ship_snapshot_window(realm)` — anchored on the realm's latest `ShipTopPlayerSnapshot.captured_on`, so a clicked treemap tile and its drill-down board cover the **identical date span** (no off-by-a-window mismatch). Results are cached per bucket under a **window-end-tagged** key (`top-ships:<mode>:win<YYYY-MM-DD>:<limit>` and `ships-by:<mode>:win<YYYY-MM-DD>:t<tier>:<type>`), so when a new nightly snapshot lands the key changes and the next request recomputes over the matching window — **alignment self-heals regardless of beat order.**
 
-**Fix (shipped):** `warm_realm_top_ships_task` (`tasks.py`) — the existing daily per-realm landing warmer (Beat `top-ships-warmer-{realm}`, ~00:05/00:10/00:15 striped) — now also force-recomputes all populated tier/type buckets (`mode="random"` only; the frontend never passes a mode) right after it warms the treemap. One daily pass makes every filter click a guaranteed Redis hit for the season. Buckets with no candidate ships short-circuit before the aggregation and aren't cached — that cheap early-return path was never the lag source. Tests: `test_realm_ships_by_tier_type.py::RealmShipsByTierTypeWarmTests`.
+**Switch-lag warming:** there are **3 tiers × 5 types = 15 buckets per realm**; cold, the first click of a new combination would pay the full aggregation on the request path. `warm_realm_top_ships_task` (Beat `top-ships-warmer-{realm}`) force-recomputes both treemap modes + every populated tier/type bucket once a day. It is scheduled **~1h after that realm's nightly snapshot** (snapshot ~02:30, warm ~03:xx striped) so it warms the *current* window rather than the previous day's. Buckets with no candidate ships short-circuit before the aggregation and aren't cached — that cheap early-return path was never the lag source. Tests: `test_realm_ships_by_tier_type.py::RealmShipsByTierTypeWarmTests`.
 
 ## Diagnosing "the leaderboard looks stale"
 
-1. **Is it within a season?** If `today` is between the current `captured_on` and `captured_on + 14d`, static is expected. Check `next_window_open` for the next drop. **Not a bug.**
-2. **Did the boundary pass but the board didn't update?** Confirm `SHIP_BADGE_SNAPSHOT_ENABLED=1`, then check whether `snapshot_ship_top_players_task` ran on the boundary Monday (Beat health, task logs). If `captured_on` is two+ seasons behind, the writer didn't fire — investigate the `background` worker / Beat, not the read path.
-3. **Stale only for ~15 min after a known boundary?** That's the Redis + client caches draining. Harmless.
-4. **A specific strong player is missing a badge/standing** — this is usually sparse `BattleObservation` mis-bucketing by `detected_at`, a separate concern (see `runbook-ship-top-player-badges-2026-06-05.md`), not a leaderboard-freshness issue.
+1. **Is the newest `captured_on` today/yesterday?** If so, static *within the day* is expected — it advances on the next nightly run. **Not a bug.**
+2. **Is `captured_on` several days behind?** Confirm `SHIP_BADGE_SNAPSHOT_ENABLED=1`, then check whether `snapshot_ship_top_players_task` ran (Beat health, task logs). If it's stuck, investigate the `background` worker / Beat, not the read path.
+3. **Treemap/list disagree with a ship's drill-down board?** They share the rolling window via `latest_ship_snapshot_window`, but a ship not ranked on the latest night keeps an older per-ship `captured_on`, so its `/ship/<id>` window can lag the realm-wide treemap by a snapshot. Pre-existing and minor.
+4. **Stale only for ~15 min after a known nightly run?** That's the Redis + client caches draining. Harmless.
+5. **A specific strong player is missing a badge/standing** — this is usually sparse `BattleObservation` mis-bucketing by `detected_at`, a separate concern (see `runbook-ship-top-player-badges-2026-06-05.md`), not a leaderboard-freshness issue.
 
-## If real-time-ish ship stats are ever required
+## If even-fresher ship stats are ever required
 
-This is a deliberate snapshot-backed design (cheap reads, no population-wide live aggregation on request). Closing the staleness gap is a **non-trivial** change, not a config tweak:
+This is a deliberate snapshot-backed design (cheap reads, no population-wide live aggregation on request). The window now advances nightly; closing the remaining ≤1-day gap is a **non-trivial** change, not a config tweak:
 
-- **Shorten the window** (e.g. weekly season) — more frequent drops, but smaller per-window battle samples (noisier standings) and 2× the snapshot churn/pruning.
+- **Shorten the window** — smaller per-window battle samples (noisier standings); tunable via `SHIP_LEADERBOARD_WINDOW_DAYS` but it trades sample size for recency.
 - **Add a live-aggregation path** — on-request or short-TTL recompute of `BattleEvent` deltas per ship; far more expensive (the reason the snapshot model exists), would need its own caching/work-mem budget.
 
 Neither should be undertaken as a quick fix; size it as a feature.
 
 ## Related runbooks
 
-- `agents/runbooks/runbook-ship-top-player-badges-2026-06-05.md` — the snapshot/badge engine, season-boundary semantics, `detected_at` bucketing caveats.
-- `agents/runbooks/runbook-ship-award-ledger-2026-06-05.md` — the durable `ShipAward` career ledger (distinct from the ephemeral leaderboard snapshot).
+- `agents/runbooks/runbook-ship-badges-rolling-2026-06-14.md` — the canonical rolling-nightly snapshot/badge engine + Ship Honors removal.
+- `agents/runbooks/runbook-ship-top-player-badges-2026-06-05.md` — the original snapshot/badge engine design (ranking, population guards, `detected_at` bucketing caveats); cadence sections superseded by the rolling runbook.
 - `agents/runbooks/runbook-cache-audit.md` — cache families, TTLs, and invalidation across the app.

--- a/agents/runbooks/runbook-seo.md
+++ b/agents/runbooks/runbook-seo.md
@@ -47,6 +47,8 @@ The root `layout.tsx` exports a static `metadata` object. Player and clan pages 
 - Bulk cache players (~50) and clans (~25)
 - Recently visited players and clans (from `EntityVisitDaily`, last 30 days, with deduped views ≥ 2)
 
+> **Hidden-profile filter (2026-06-15):** `sitemap_entities` now joins `Player` and drops `is_hidden=True` accounts (and visited ids with no `Player` row — deleted/never-ingested). A hidden profile renders only a "stats hidden" placeholder, so emitting it is a thin-content / dead-end URL for crawlers — an audit found ~40% of the most-visited players were hidden. The view over-fetches `3×` the player cap before filtering so the post-filter list still reaches 200. `is_hidden` is the last-known fetch state, so a just-un-hidden player re-enters on its next visit/refresh. Covered by `test_views.py::SitemapEntitiesTests`.
+
 This gives search engines a curated, high-quality set of 100-500 URLs without trying to index stale or never-visited player profiles.
 
 ### 3. No Open Graph or Twitter Card Metadata

--- a/agents/runbooks/runbook-ship-badges-rolling-2026-06-14.md
+++ b/agents/runbooks/runbook-ship-badges-rolling-2026-06-14.md
@@ -147,11 +147,41 @@ droplet via `/opt/battlestats-server/venv/bin/python manage.py shell` with
   + season-window defaults + weekly crontab). The `ShipAward` table drop is the only
   irreversible step — it is empty in prod, so the loss is nil.
 
+## Addendum (2026-06-15): realm treemap + inline list moved to the rolling window
+
+The 2026-06-14 change rolled the **badges + `/ship` board**, but left the landing
+**realm treemap** (`compute_realm_top_ships`) and **tier/type drill-down list**
+(`compute_realm_ships_by_tier_type`) on the retired fixed `SHIP_SEASON_*` 2-week
+season. That left them misaligned with the player lists — and the inline list was in
+fact returning empty in prod (it looked up `ShipTopPlayerSnapshot` at
+`captured_on=season_start`, ~21 days old vs the table's ~5-day retention). Both were
+repointed to the same rolling window the board reads:
+
+- New `latest_ship_snapshot_window(realm)` resolves `(captured_on, window_start,
+  window_end)` from the realm's latest `ShipTopPlayerSnapshot.captured_on` —
+  `[captured_on - SHIP_LEADERBOARD_WINDOW_DAYS, captured_on)` — so treemap, inline
+  list, and `/ship` board cover the **identical** date span.
+- Caches are keyed on the window-end date (`…:win<YYYY-MM-DD>:…`); when a new
+  snapshot lands the key changes and the next request recomputes → alignment
+  **self-heals regardless of beat order.**
+- The `top-ships-warmer-{realm}` Beat task was moved to fire **~1h after** that
+  realm's nightly snapshot (was hour 0, before it) so it warms the current window.
+- The fixed-season helpers (`SHIP_SEASON_EPOCH`, `SHIP_SEASON_LENGTH_DAYS`,
+  `ship_season_bounds`, `current_season_index`, `most_recent_completed_season`) are
+  **deleted** — the treemap was their last consumer. Frontend `shipSeason.ts` trimmed
+  to the one date-range formatter still used. Payloads now expose
+  `{window_days, captured_on, window_start, window_end}` (was `{days, season_index,
+  season_start, season_end}`). Tests: `test_realm_top_ships.py`,
+  `test_realm_ships_by_tier_type.py`.
+
 ## Follow-ups
 
 - **Done at implementation (2026-06-14):** archived `runbook-ship-award-ledger-2026-06-05.md`;
   updated `runbook-ship-top-player-badges-2026-06-05.md` to the rolling model; reconciled
   `CLAUDE.md` (Ship standings paragraph, data-models list, kill-switch list).
+- **Done 2026-06-15:** treemap + inline list rolled to the same window (see Addendum above);
+  reconciled `runbook-leaderboard-updates.md` and the `runbook-ship-top-player-badges-2026-06-05.md`
+  treemap addendum.
 - **Remaining — deploy:** backend deploy runs the `0071_delete_shipaward` migration
   (table drop, empty in prod); then **rebuild + deploy the frontend** (ShipHonors removal
   + `/ship` copy are FE). After the first nightly run per realm, confirm exec time ≤~12 s,

--- a/agents/runbooks/runbook-ship-top-player-badges-2026-06-05.md
+++ b/agents/runbooks/runbook-ship-top-player-badges-2026-06-05.md
@@ -7,8 +7,10 @@
 > `SHIP_LEADERBOARD_WINDOW_DAYS` (14) window, `captured_on` is the **run date**, badges are
 > worn **only while held**, and the durable `ShipAward` ledger / **Ship Honors panel was
 > removed entirely** (the HELD-awards banner below is historical). `SHIP_AWARD_LEDGER_ENABLED`,
-> the `backfill_ship_seasons` command, and `is_season_boundary` are gone; the fixed-season
-> helpers remain only for the realm treemap. Authoritative reference:
+> the `backfill_ship_seasons` command, and `is_season_boundary` are gone. **As of 2026-06-15
+> the realm treemap + inline tier/type list also moved to the rolling window and the
+> fixed-season helpers were deleted entirely** (the treemap Addendum below is historical).
+> Authoritative reference:
 > [runbook-ship-badges-rolling-2026-06-14.md](runbook-ship-badges-rolling-2026-06-14.md).
 
 _Created: 2026-06-05_
@@ -395,6 +397,13 @@ Scope widened from **T10 only** to **T8–T10** after a per-tier density study o
   tiers via the now-multi-tier compute) → deploy frontend.
 
 ## Addendum (2026-06-05, later): landing treemap aligned to the completed season
+
+> **SUPERSEDED 2026-06-15 — treemap + inline list now use the rolling window.** The
+> fixed-season alignment described below was replaced when the badges/board went rolling
+> (2026-06-14): the treemap and inline tier/type list now anchor on the latest snapshot's
+> `captured_on` (`latest_ship_snapshot_window`), payloads expose `{window_days, captured_on,
+> window_start, window_end}`, caches are window-end-tagged, and the season helpers are
+> deleted. See the Addendum in `runbook-ship-badges-rolling-2026-06-14.md`.
 
 The `RealmTopShipsTreemapSVG` / `compute_realm_top_ships` window was switched from a
 rolling window (24h → 7d earlier in the day) to the **most recently completed fixed

--- a/client/app/components/RealmTopShipsTreemapSVG.tsx
+++ b/client/app/components/RealmTopShipsTreemapSVG.tsx
@@ -2,12 +2,13 @@
 
 // Realm top-ships treemap.
 //
-// The 25 most-played ships on the active realm over the MOST RECENTLY COMPLETED
-// 2-WEEK SHIP SEASON (the same window the /ship leaderboard + profile medals
-// reflect), as a treemap: each tile is one ship, sized by battles, COLORED BY
-// SHIP TYPE and SHADED BY TIER (lighter = low tier, darker = high tier). Fed by
-// `/api/realm/<realm>/top-ships`, a static per-season count that aggregates
-// BattleEvent over the completed-season window and joins Ship for type/tier.
+// The 25 most-played ships on the active realm over the ROLLING TRAILING 14-DAY
+// SHIP-STANDINGS WINDOW (the same window the /ship leaderboard + profile medals
+// read — 1:1 with the player lists), as a treemap: each tile is one ship, sized
+// by battles, COLORED BY SHIP TYPE and SHADED BY TIER (lighter = low tier, darker
+// = high tier). Fed by `/api/realm/<realm>/top-ships`, recomputed nightly: it
+// aggregates BattleEvent over the latest snapshot's window and joins Ship for
+// type/tier.
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -33,11 +34,11 @@ type ShipMode = 'random' | 'ranked';
 
 interface RealmTopShips {
     realm: string;
-    days?: number;
+    window_days?: number;
     mode?: ShipMode;
-    season_index?: number;
-    season_start?: string;  // date-only ISO (UTC midnight), inclusive
-    season_end?: string;    // date-only ISO (UTC midnight), exclusive
+    captured_on?: string | null;  // latest snapshot run date (== window_end), null if none yet
+    window_start?: string;  // date-only ISO (UTC midnight), inclusive
+    window_end?: string;    // date-only ISO (UTC midnight), exclusive (== captured_on)
     ships: TopShip[];
 }
 
@@ -45,10 +46,10 @@ const SHIP_MODES: ShipMode[] = ['random', 'ranked'];
 const SHIP_MODE_LABEL: Record<ShipMode, string> = { random: 'Random', ranked: 'Ranked' };
 
 const SHIP_LIMIT = 25;
-// 1h client TTL. The payload only changes once per 2-week season (static
-// per-season count), but a short client TTL keeps a tab left open across a
-// season boundary from showing the stale window for long; the backend serves it
-// from a warm season-tagged cache.
+// 1h client TTL. The payload changes once per night (rolling trailing window,
+// recomputed with the nightly snapshot); a short client TTL keeps a long-open tab
+// from showing the previous day's window for long. The backend serves it from a
+// warm window-end-tagged cache.
 const TOP_SHIPS_FETCH_TTL_MS = 3_600_000;
 
 const TYPE_LABEL: Record<string, string> = {
@@ -157,16 +158,16 @@ const RealmTopShipsTreemapSVG: React.FC<RealmTopShipsTreemapSVGProps> = ({ onSel
         [width],
     );
 
-    // Season range label (e.g. "11–24 May") from the payload's date-only bounds.
-    // `season_end` is the exclusive next-season start; formatSeasonLabel already
-    // steps back a day for the last included date.
-    const seasonLabel = useMemo(() => {
-        if (!data?.season_start || !data?.season_end) return null;
-        const startMs = Date.parse(data.season_start);
-        const endMs = Date.parse(data.season_end);
+    // Rolling-window range label (e.g. "1–14 Jun") from the payload's date-only
+    // bounds. `window_end` is the exclusive end (== the snapshot's captured_on);
+    // formatSeasonLabel already steps back a day for the last included date.
+    const windowLabel = useMemo(() => {
+        if (!data?.window_start || !data?.window_end) return null;
+        const startMs = Date.parse(data.window_start);
+        const endMs = Date.parse(data.window_end);
         if (Number.isNaN(startMs) || Number.isNaN(endMs)) return null;
         return formatSeasonLabel(startMs, endMs);
-    }, [data?.season_start, data?.season_end]);
+    }, [data?.window_start, data?.window_end]);
 
     useEffect(() => {
         if (!svgRef.current || !data || width <= 0 || data.ships.length === 0) return;
@@ -275,7 +276,7 @@ const RealmTopShipsTreemapSVG: React.FC<RealmTopShipsTreemapSVGProps> = ({ onSel
             <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
                 <div className="flex items-center gap-3">
                     <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                        {displayRealm.toUpperCase()} most-played ships{seasonLabel ? ` · ${seasonLabel}` : ' · Last season'}
+                        {displayRealm.toUpperCase()} most-played ships · Last 14 days{windowLabel ? ` · ${windowLabel}` : ''}
                     </h2>
                     <div className="flex items-center gap-1 text-xs" role="group" aria-label="Battle mode">
                         {SHIP_MODES.map((m) => (
@@ -297,7 +298,7 @@ const RealmTopShipsTreemapSVG: React.FC<RealmTopShipsTreemapSVGProps> = ({ onSel
                 </div>
             </div>
             <div ref={containerRef} className="relative w-full max-w-[900px]">
-                <svg ref={svgRef} role="img" aria-label={`${displayRealm} top ${SHIP_LIMIT} most-played ships over the most recently completed 2-week ship season`} />
+                <svg ref={svgRef} role="img" aria-label={`${displayRealm} top ${SHIP_LIMIT} most-played ships over the rolling trailing 14-day ship-standings window`} />
                 {hover && (
                     <div
                         className="pointer-events-none absolute z-10 rounded bg-[var(--bg-page)] px-2 py-1 text-xs shadow-md ring-1 ring-[var(--accent-faint)]"

--- a/client/app/components/ShipLeaderboard.tsx
+++ b/client/app/components/ShipLeaderboard.tsx
@@ -81,8 +81,9 @@ interface ShipLeaderboardPayload {
     players: LeaderboardPlayer[];
 }
 
-// The list only changes once per 2-week season; a 1h client TTL keeps a long-open
-// tab from showing a stale window past a boundary (backend serves it warm).
+// The list changes once per night (rolling trailing window, recomputed with the
+// nightly snapshot); a 1h client TTL keeps a long-open tab from showing the
+// previous day's window for long (backend serves it warm).
 const LIST_FETCH_TTL_MS = 3_600_000;
 const BOARD_FETCH_TTL_MS = 900_000; // 15 min, matching the /ship page.
 
@@ -157,7 +158,7 @@ const ariaSort = (active: boolean, dir: SortDir): 'ascending' | 'descending' | '
     active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none';
 
 const DATA_BASIS_HINT =
-    'Stats are aggregated from battle observations recorded during the current two-week period.';
+    'Stats are aggregated from battle observations recorded during the rolling trailing 14-day window.';
 
 // Info affordance with a hover/focus tooltip — styled to match the circle-info
 // buttons in the Players/Clans landing sections below (FontAwesomeIcon + the

--- a/client/app/lib/shipSeason.ts
+++ b/client/app/lib/shipSeason.ts
@@ -1,39 +1,15 @@
-// Fixed two-week "ship standings" seasons.
+// Ship-standings window label formatter.
 //
-// The standings pivot from a rolling trailing 14 days to fixed, non-overlapping
-// calendar fortnights anchored to ISO week 20 of 2026 — Monday 11 May 2026,
-// 00:00 UTC. Each season is exactly 14 days; season N covers
-// [epoch + N*14d, epoch + (N+1)*14d). This makes the schedule deterministic and
-// identical for every player, and gives a well-defined "next window opens" time.
-//
-// IMPORTANT: when the backend snapshot/award job adopts fixed windows it MUST use
-// this same epoch + length, so the data on the page matches the countdown shown.
+// The ship standings (treemap, /ship leaderboards, profile medals) are a rolling
+// trailing 14-day window recomputed nightly — there is no fixed "season" anymore
+// (the fixed-fortnight model was retired 2026-06-15). This module keeps the one
+// helper still needed: a UTC date-range label for that window's [start, end)
+// bounds, e.g. "11–24 May". Dates are formatted in UTC since the window bounds
+// are UTC-anchored (the backend buckets by UTC date).
 
-export const SHIP_SEASON_EPOCH_MS = Date.UTC(2026, 4, 11); // Mon 11 May 2026, 00:00 UTC (month is 0-indexed)
-export const SHIP_SEASON_LENGTH_MS = 14 * 24 * 60 * 60 * 1000;
-
-export interface ShipSeasonWindow {
-    index: number;   // 0 = W20-21 (11-24 May 2026)
-    startMs: number; // inclusive
-    endMs: number;   // exclusive — also the moment the next window opens
-}
-
-// The fixed season containing `nowMs`. Before the epoch this returns season 0.
-export function currentShipSeason(nowMs: number): ShipSeasonWindow {
-    const elapsed = nowMs - SHIP_SEASON_EPOCH_MS;
-    const index = Math.max(0, Math.floor(elapsed / SHIP_SEASON_LENGTH_MS));
-    const startMs = SHIP_SEASON_EPOCH_MS + index * SHIP_SEASON_LENGTH_MS;
-    return { index, startMs, endMs: startMs + SHIP_SEASON_LENGTH_MS };
-}
-
-// Epoch ms at which the next window opens (== current window's exclusive end).
-export function nextWindowOpenMs(nowMs: number): number {
-    return currentShipSeason(nowMs).endMs;
-}
-
-// Season label from its [start, end) bounds, e.g. "11–24 May". `endMs` is the
-// exclusive end (next window open), so the last included day is endMs - 1 day.
-// Dates are formatted in UTC since seasons are UTC-anchored.
+// Range label from [start, end) bounds, e.g. "11–24 May". `endMs` is the
+// exclusive end (== the snapshot's captured_on), so the last included day is
+// endMs - 1 day.
 export function formatSeasonLabel(startMs: number, endMs: number): string {
     const start = new Date(startMs);
     const lastDay = new Date(endMs - 24 * 60 * 60 * 1000);
@@ -43,43 +19,4 @@ export function formatSeasonLabel(startMs: number, endMs: number): string {
     return sameMonth
         ? `${day(start)}–${day(lastDay)} ${mon(lastDay)}`
         : `${day(start)} ${mon(start)} – ${day(lastDay)} ${mon(lastDay)}`;
-}
-
-// ISO-8601 week number + week-year for a UTC timestamp. Used to label a season
-// by its starting week, e.g. season 0 (Mon 11 May 2026) → { week: 20, year: 2026 }.
-export function isoWeek(ms: number): { week: number; year: number } {
-    const d = new Date(ms);
-    const target = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-    const dayNr = (target.getUTCDay() + 6) % 7;          // Mon=0 … Sun=6
-    target.setUTCDate(target.getUTCDate() - dayNr + 3);  // Thursday of this ISO week
-    const year = target.getUTCFullYear();                // ISO week-year
-    const firstThursday = new Date(Date.UTC(year, 0, 4));
-    const firstDayNr = (firstThursday.getUTCDay() + 6) % 7;
-    firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNr + 3);
-    const week = 1 + Math.round((target.getTime() - firstThursday.getTime()) / (7 * 86_400_000));
-    return { week, year };
-}
-
-// Season week label, e.g. "WK20" or (with year) "WK20'26". `ms` is a season-start
-// timestamp (ISO date-only strings parse as UTC midnight).
-export function formatWeek(ms: number, withYear = false): string {
-    const { week, year } = isoWeek(ms);
-    // A season spans two ISO weeks; label it WK<n>-<n2> where n2 is the window's
-    // second calendar week (computed, so year-boundary wraps like 52→1 are correct).
-    const week2 = isoWeek(ms + 7 * 24 * 60 * 60 * 1000).week;
-    const base = `WK${week}-${week2}`;
-    return withYear ? `${base}'${String(year).slice(-2)}` : base;
-}
-
-// Compact human duration, e.g. "2d 14h", "14h 03m", "07m". Floors to the minute.
-export function formatCountdown(ms: number): string {
-    if (ms <= 0) return 'now';
-    const totalMin = Math.floor(ms / 60_000);
-    const days = Math.floor(totalMin / (60 * 24));
-    const hours = Math.floor((totalMin % (60 * 24)) / 60);
-    const mins = totalMin % 60;
-    const pad = (n: number) => String(n).padStart(2, '0');
-    if (days > 0) return `${days}d ${pad(hours)}h`;
-    if (hours > 0) return `${hours}h ${pad(mins)}m`;
-    return `${pad(mins)}m`;
 }

--- a/server/warships/data.py
+++ b/server/warships/data.py
@@ -5908,44 +5908,46 @@ SHIP_LEADERBOARD_WINDOW_DAYS = int(os.getenv('SHIP_LEADERBOARD_WINDOW_DAYS', '14
 SHIP_LEADERBOARD_CACHE_TTL = 900   # 15 min read-cache on the /ship endpoint
 
 
-# --- Fixed 2-week ship "seasons" (treemap only) -----------------------------
-# The ship board + profile badges are NOW a nightly rolling trailing window (see
-# SHIP_LEADERBOARD_WINDOW_DAYS); they no longer use these season bounds. The
-# realm treemap (compute_realm_top_ships) still buckets by a fixed, immutable
-# 2-week calendar season so its per-season cache key is stable — that is the only
-# remaining consumer of this epoch/length and the frontend mirror in
-# client/app/lib/shipSeason.ts (used by RealmTopShipsTreemapSVG).
-SHIP_SEASON_EPOCH = date(2026, 5, 11)   # Mon 11 May 2026 (UTC) — season 0 start
-SHIP_SEASON_LENGTH_DAYS = 14            # treemap season length (decoupled from the badge window)
+# --- Rolling ship-standings window (treemap + inline list) -------------------
+# The realm treemap (compute_realm_top_ships) and the landing inline tier/type
+# list (compute_realm_ships_by_tier_type) align 1:1 with the /ship/<id> player
+# leaderboards: all three cover the SAME rolling trailing
+# SHIP_LEADERBOARD_WINDOW_DAYS window the nightly ShipTopPlayerSnapshot was built
+# over. The fixed 2-week "season" model that previously bucketed the treemap was
+# retired 2026-06-15 when the badges/leaderboards moved to a nightly rolling
+# window (see runbook-ship-badges-rolling-2026-06-14.md); the frontend mirror
+# lives in client/app/lib/shipSeason.ts.
 
 
-def ship_season_bounds(index: int) -> tuple:
-    """(`start`, `end`) dates for season `index`; start inclusive, end exclusive."""
-    start = SHIP_SEASON_EPOCH + timedelta(days=index * SHIP_SEASON_LENGTH_DAYS)
-    return start, start + timedelta(days=SHIP_SEASON_LENGTH_DAYS)
+def latest_ship_snapshot_window(realm: str) -> tuple:
+    """(`captured_on`, `window_start`, `window_end`) for a realm's ship standings.
 
-
-def current_season_index(today: Optional[date] = None) -> int:
-    """Index of the season in progress at `today` (clamped at 0 before the epoch)."""
-    today = today or django_timezone.now().date()
-    return max(0, (today - SHIP_SEASON_EPOCH).days // SHIP_SEASON_LENGTH_DAYS)
-
-
-def most_recent_completed_season(today: Optional[date] = None) -> tuple:
-    """(`index`, `start`, `end`) of the most recently *finished* season at `today`.
-
-    Before the first boundary (mid season 0) there is no completed season; we
-    clamp to season 0, but the runtime task is boundary-gated so it never asks
-    for a not-yet-complete season at runtime.
+    Anchors on the realm's most recent ``ShipTopPlayerSnapshot.captured_on`` — the
+    exact rolling window the ``/ship`` leaderboards read — so the treemap and the
+    inline tier/type list cover the identical date span as the player lists.
+    ``window_end`` is that ``captured_on`` (exclusive end, a run date);
+    ``window_start = window_end - SHIP_LEADERBOARD_WINDOW_DAYS``. Keying caches on
+    ``window_end`` makes alignment self-heal the moment a new nightly snapshot
+    lands (the key changes; the next request recomputes over the matching window).
+    Falls back to a trailing window ending today when no snapshot exists yet
+    (``captured_on`` is then ``None``).
     """
-    today = today or django_timezone.now().date()
-    idx = max(0, current_season_index(today) - 1)
-    start, end = ship_season_bounds(idx)
-    return idx, start, end
+    from warships.models import ShipTopPlayerSnapshot
+
+    realm = (realm or DEFAULT_REALM).lower().strip()
+    captured_on = (
+        ShipTopPlayerSnapshot.objects.filter(realm=realm)
+        .order_by('-captured_on')
+        .values_list('captured_on', flat=True)
+        .first()
+    )
+    window_end = captured_on or django_timezone.now().date()
+    window_start = window_end - timedelta(days=SHIP_LEADERBOARD_WINDOW_DAYS)
+    return captured_on, window_start, window_end
 
 
 def _season_window_datetimes(start: date, end: date) -> tuple:
-    """Datetimes for a season's [start, end) date bounds (UTC midnight).
+    """Datetimes for a window's [start, end) date bounds (UTC midnight).
 
     Respects `USE_TZ`: aware UTC in production (matching `BattleEvent.detected_at`),
     naive under the sqlite test config — mirroring how the previous `since =
@@ -6469,15 +6471,16 @@ def get_ship_leaderboard(realm: str, ship_id: int) -> Optional[dict]:
 
 
 def compute_realm_top_ships(realm, limit=25, mode="random", use_cache=True):
-    """Most-played ships on a realm over the most recently completed ship season.
+    """Most-played ships on a realm over the rolling ship-standings window.
 
     Sums ``BattleEvent.battles_delta`` per ship — filtered by realm + mode over the
-    most recently *completed* fixed 2-week ship season (the same window the
-    ``/ship/<id>`` leaderboard and profile medals reflect; see
-    ``most_recent_completed_season``) — joins ``Ship`` for type/tier, and returns
-    the top-``limit`` as a payload dict. A closed season's window is immutable (no
-    new events ever fall inside it), so this is computed once per season and cached
-    under a season-tagged key until the next boundary. Shared by the
+    **rolling trailing ``SHIP_LEADERBOARD_WINDOW_DAYS`` window the ``/ship/<id>``
+    leaderboards + profile medals read** (anchored on the latest
+    ``ShipTopPlayerSnapshot.captured_on``; see ``latest_ship_snapshot_window``) —
+    joins ``Ship`` for type/tier, and returns the top-``limit`` as a payload dict.
+    The window advances each night with the snapshot, so the cache key carries the
+    window-end date: when a new snapshot lands the key changes and the next request
+    recomputes over the matching window (1:1 with the player lists). Shared by the
     ``realm_top_ships`` API view and the daily ``warm_realm_top_ships_task``
     warmer; pass ``use_cache=False`` to force a recompute.
     """
@@ -6493,15 +6496,16 @@ def compute_realm_top_ships(realm, limit=25, mode="random", use_cache=True):
         limit = 25
     limit = max(5, min(limit, 50))
 
-    # Window: the most recently completed fixed 2-week ship season, aligning the
-    # treemap with the /ship leaderboard + profile medals (identical season
-    # bounds). A closed season's window is immutable, so the aggregation only
-    # changes at a season boundary — the cache key carries the season index and
-    # the TTL runs to the next boundary.
-    season_idx, season_start, season_end = most_recent_completed_season()
-    window_start, window_end = _season_window_datetimes(season_start, season_end)
+    # Window: the rolling trailing window the /ship leaderboards read (anchored on
+    # the latest snapshot's captured_on), so the treemap covers the identical date
+    # span as the player lists. The cache key carries the window-end date, so when
+    # a new nightly snapshot lands the key changes and the next request recomputes
+    # over the matching window — alignment self-heals regardless of beat order.
+    captured_on, window_start_d, window_end_d = latest_ship_snapshot_window(realm)
+    window_start, window_end = _season_window_datetimes(window_start_d, window_end_d)
 
-    cache_key = realm_cache_key(realm, f"top-ships:{mode}:season{season_idx}:{limit}")
+    cache_key = realm_cache_key(
+        realm, f"top-ships:{mode}:win{window_end_d.isoformat()}:{limit}")
     if use_cache:
         cached = cache.get(cache_key)
         if cached is not None:
@@ -6535,24 +6539,17 @@ def compute_realm_top_ships(realm, limit=25, mode="random", use_cache=True):
 
     payload = {
         "realm": realm,
-        "days": SHIP_SEASON_LENGTH_DAYS,
-        "season_index": season_idx,
-        "season_start": season_start.isoformat(),  # date-only ISO (UTC midnight)
-        "season_end": season_end.isoformat(),      # exclusive end (next season start)
-        "window_start": window_start.isoformat(),
-        "window_end": window_end.isoformat(),
+        "window_days": SHIP_LEADERBOARD_WINDOW_DAYS,
+        "captured_on": captured_on.isoformat() if captured_on else None,
+        "window_start": window_start_d.isoformat(),  # date-only ISO (UTC midnight), inclusive
+        "window_end": window_end_d.isoformat(),      # exclusive end (== captured_on)
         "mode": mode,
         "ships": payload_ships,
     }
-    # Cache until ~1h past the next season boundary: at that point
-    # most_recent_completed_season advances, the season-tagged key changes, and
-    # the daily warmer recomputes the new season. The closed-season aggregation is
-    # immutable until then, so the (up to ~2 week) TTL is safe.
-    now = django_timezone.now()
-    _, current_season_end = ship_season_bounds(current_season_index())
-    next_boundary_dt, _ = _season_window_datetimes(current_season_end, current_season_end)
-    ttl = max(3600, int((next_boundary_dt - now).total_seconds()) + 3600)
-    cache.set(cache_key, payload, timeout=ttl)
+    # Rolling window keyed by its end date; refreshed nightly by the warmer after
+    # the snapshot lands. A 26h TTL bridges the daily warms without ever serving a
+    # window the snapshot has already advanced past (the key changes at that point).
+    cache.set(cache_key, payload, timeout=26 * 3600)
     return payload
 
 
@@ -6568,21 +6565,24 @@ SHIP_LIST_MIN_BATTLES = int(os.getenv('SHIP_LIST_MIN_BATTLES', '50'))
 
 def compute_realm_ships_by_tier_type(realm, tier, ship_type, mode="random",
                                      min_battles=None, use_cache=True):
-    """Ships of one tier+type on a realm, ranked by win rate over the last season.
+    """Ships of one tier+type on a realm, ranked by win rate over the rolling window.
 
     Powers the landing-page inline ship leaderboard (the filterable table under
     the treemap). Aggregates ``BattleEvent`` deltas per ship — realm + mode, over
-    the most recently *completed* fixed 2-week ship season (the same window the
-    treemap, the ``/ship/<id>`` board and profile medals reflect) — to realm-wide
-    win rate / avg damage / kills per battle, then orders by win rate descending.
+    the **rolling trailing ``SHIP_LEADERBOARD_WINDOW_DAYS`` window the treemap, the
+    ``/ship/<id>`` board and profile medals read** (anchored on the latest
+    ``ShipTopPlayerSnapshot.captured_on``; see ``latest_ship_snapshot_window``) —
+    to realm-wide win rate / avg damage / kills per battle, then orders by win rate
+    descending.
 
     The candidate set is restricted to ships that hold a ``ShipTopPlayerSnapshot``
-    row for that season (i.e. ships that cleared the population guard and have a
-    populated drill-down board), so every listed ship reliably opens a non-empty
-    leaderboard and the snapshot's population guard doubles as the sample floor.
+    row for the **latest** ``captured_on`` (i.e. ships that cleared the population
+    guard in the current window and have a populated drill-down board), so every
+    listed ship reliably opens a non-empty leaderboard and the snapshot's
+    population guard doubles as the sample floor.
 
-    A closed season's window is immutable, so this is computed once per season and
-    cached under a season-tagged key until the next boundary (mirrors
+    The window advances nightly with the snapshot, so this is cached under a
+    window-end-tagged key and refreshed by the daily warmer (mirrors
     ``compute_realm_top_ships``). Returns a payload dict; ``ships`` is ``[]`` when
     no ship in the bucket qualifies. ``tier``/``ship_type`` are assumed validated
     by the caller (the view rejects out-of-range values).
@@ -6601,11 +6601,11 @@ def compute_realm_ships_by_tier_type(realm, tier, ship_type, mode="random",
     if min_battles is None:
         min_battles = SHIP_LIST_MIN_BATTLES
 
-    season_idx, season_start, season_end = most_recent_completed_season()
-    window_start, window_end = _season_window_datetimes(season_start, season_end)
+    captured_on, window_start_d, window_end_d = latest_ship_snapshot_window(realm)
+    window_start, window_end = _season_window_datetimes(window_start_d, window_end_d)
 
     cache_key = realm_cache_key(
-        realm, f"ships-by:{mode}:season{season_idx}:t{tier}:{ship_type}")
+        realm, f"ships-by:{mode}:win{window_end_d.isoformat()}:t{tier}:{ship_type}")
     if use_cache:
         cached = cache.get(cache_key)
         if cached is not None:
@@ -6613,23 +6613,23 @@ def compute_realm_ships_by_tier_type(realm, tier, ship_type, mode="random",
 
     payload = {
         "realm": realm,
-        "days": SHIP_SEASON_LENGTH_DAYS,
+        "window_days": SHIP_LEADERBOARD_WINDOW_DAYS,
         "tier": tier,
         "ship_type": ship_type,
         "mode": mode,
-        "season_index": season_idx,
-        "season_start": season_start.isoformat(),
-        "season_end": season_end.isoformat(),
-        "window_start": window_start.isoformat(),
-        "window_end": window_end.isoformat(),
+        "captured_on": captured_on.isoformat() if captured_on else None,
+        "window_start": window_start_d.isoformat(),
+        "window_end": window_end_d.isoformat(),
         "ships": [],
     }
+    if captured_on is None:
+        return payload  # no snapshot yet → no candidate ships
 
-    # Candidate ships: this tier+type AND ranked in the latest snapshot season
+    # Candidate ships: this tier+type AND ranked in the latest snapshot
     # (guarantees a populated drill-down board for every listed ship).
     snapshot_ids = set(
         ShipTopPlayerSnapshot.objects
-        .filter(realm=realm, captured_on=season_start)
+        .filter(realm=realm, captured_on=captured_on)
         .values_list('ship_id', flat=True)
     )
     if not snapshot_ids:
@@ -6685,9 +6685,7 @@ def compute_realm_ships_by_tier_type(realm, tier, ship_type, mode="random",
     payload_ships.sort(key=lambda s: (-s["win_rate"], -s["battles"]))
     payload["ships"] = payload_ships
 
-    now = django_timezone.now()
-    _, current_season_end = ship_season_bounds(current_season_index())
-    next_boundary_dt, _ = _season_window_datetimes(current_season_end, current_season_end)
-    ttl = max(3600, int((next_boundary_dt - now).total_seconds()) + 3600)
-    cache.set(cache_key, payload, timeout=ttl)
+    # Rolling window keyed by its end date; refreshed nightly by the warmer. The
+    # 26h TTL bridges the daily warms; the key changes once a new snapshot lands.
+    cache.set(cache_key, payload, timeout=26 * 3600)
     return payload

--- a/server/warships/hot_players.py
+++ b/server/warships/hot_players.py
@@ -27,7 +27,7 @@ import os
 import time
 from datetime import timedelta
 
-from django.db.models import Count, Max, Sum
+from django.db.models import Count, Exists, F, Max, OuterRef, Sum
 from django.utils import timezone
 
 from warships.models import (
@@ -78,6 +78,19 @@ def _observe_floor_hours() -> int:
 
 def _capture_delay() -> float:
     return float(os.getenv("HOT_PLAYERS_CAPTURE_DELAY", "0.5"))
+
+
+def _capture_max_pulls() -> int:
+    """Max WG fetches per capture run — the anti-starvation work budget.
+
+    Capping WG calls (not members) keeps one run safely under the task's 540s
+    soft limit even at the worst observed ~7s/pull (65 * 7 = 455s), regardless of
+    how many of the hot set are floor-missed. Members past the budget rotate in on
+    the next run (ordering by ``last_observed_at`` advances them). See
+    [[project_hot_queue_stale_seed_starves]] for why an unbudgeted all-pull sweep
+    starved the tail.
+    """
+    return int(os.getenv("HOT_CAPTURE_MAX_PULLS", "65"))
 
 
 def _backfill_active_days() -> int:
@@ -367,15 +380,28 @@ def maintain_hot_players(realm: str, *, dry_run: bool = False,
     return result
 
 
-def capture_hot_players(realm: str, *, logger=logger) -> dict:
+def capture_hot_players(realm: str, *, logger=logger, max_pulls=None) -> dict:
     """Sweep the HotPlayer set: guarantee an observation + a daily snapshot.
 
     For each member, skip-if-fresh against the latest ``BattleObservation`` (the
     floor already covers active hot players within HOT_OBSERVE_FLOOR_HOURS) else
     ``record_observation_and_diff``; and write a gap-free daily ``Snapshot`` via
     ``update_snapshot_data(refresh_player=False)`` when today's row is missing.
-    Bounded by HOT_PLAYERS_MAX, paced by HOT_PLAYERS_CAPTURE_DELAY. Hidden
-    accounts return nothing from WG and are recorded as skipped (no retry storm).
+    Hidden accounts return nothing from WG and are recorded as skipped.
+
+    **Work-budgeted + rotating (anti-starvation).** A floor-missed backfill seed is
+    all expensive pulls, so an unbudgeted ``-hot_score`` sweep blows the task's
+    540s soft limit at ~90 members and re-pulls the same static head every run
+    while the tail starves ([[project_hot_queue_stale_seed_starves]]). Instead:
+
+    * Order = engagement/pinned first (by ``-hot_score`` — few, high-value, keeps
+      their daily contract), then backfill by ``last_observed_at`` ASC NULLS FIRST
+      so the floor-missed set drains **round-robin** by coverage age.
+    * Stop after ``HOT_CAPTURE_MAX_PULLS`` actual WG fetches (success *or*
+      hidden-skip — both spend a call); members past the budget rotate in next run.
+    * Stamp ``last_observed_at`` whenever a WG call is spent on a member (pull or
+      hidden), advancing them to the back of the rotation. A cheap *fresh-skip*
+      (no WG call) is NOT stamped — those stay at the head for a free re-check.
     """
     from warships.data import update_snapshot_data
     from warships.incremental_battles import record_observation_and_diff
@@ -386,20 +412,39 @@ def capture_hot_players(realm: str, *, logger=logger) -> dict:
     stale_before = now - timedelta(hours=floor_hours)
     delay = _capture_delay()
     cap = _hot_players_max()
+    if max_pulls is None:
+        max_pulls = _capture_max_pulls()
 
-    members = list(
+    # Priority members (engagement/pinned) every run; backfill rotates by coverage
+    # age so the limited per-run WG budget walks the whole floor-missed set.
+    priority = list(
         HotPlayer.objects
         .filter(realm=realm)
+        .exclude(source=HotPlayer.SOURCE_BACKFILL)
         .select_related('player')
-        .order_by('-hot_score')[:cap]
+        .order_by('-hot_score')
     )
+    backfill = list(
+        HotPlayer.objects
+        .filter(realm=realm, source=HotPlayer.SOURCE_BACKFILL)
+        .select_related('player')
+        .order_by(F('last_observed_at').asc(nulls_first=True), '-hot_score')
+    )
+    members = (priority + backfill)[:cap]
 
     observed = obs_skipped_fresh = obs_skipped_hidden = 0
     snapshotted = snap_skipped_present = errors = 0
+    wg_calls = 0
+    processed = 0
+    stopped_early = False
 
     for hp in members:
+        if wg_calls >= max_pulls:
+            stopped_early = True
+            break
+        processed += 1
         player = hp.player
-        # --- Observation path (skip-if-fresh) ---
+        # --- Observation path (skip-if-fresh, else a budgeted WG fetch) ---
         latest = (
             BattleObservation.objects
             .filter(player=player)
@@ -408,21 +453,26 @@ def capture_hot_players(realm: str, *, logger=logger) -> dict:
             .first()
         )
         if latest is not None and latest >= stale_before:
-            obs_skipped_fresh += 1
+            obs_skipped_fresh += 1   # floor covers them; free, no stamp, no budget
         else:
+            wg_calls += 1
             try:
                 res = record_observation_and_diff(player.player_id, realm)
                 if res.get('status') == 'skipped':
                     obs_skipped_hidden += 1
                 else:
                     observed += 1
-                    hp.last_observed_at = timezone.now()
-                    hp.save(update_fields=['last_observed_at'])
+                # Stamp on any spent WG call (pull or hidden) so the member
+                # rotates to the back instead of re-burning budget every run.
+                hp.last_observed_at = timezone.now()
+                hp.save(update_fields=['last_observed_at'])
             except Exception:
                 errors += 1
                 logger.exception(
                     "hot_players[%s] capture observation failed for player_id=%s",
                     realm, player.player_id)
+            if delay:
+                time.sleep(delay)
 
         # --- Snapshot path (gap-free daily summary) ---
         if Snapshot.objects.filter(player=player, date=today).exists():
@@ -441,12 +491,14 @@ def capture_hot_players(realm: str, *, logger=logger) -> dict:
                     "hot_players[%s] capture snapshot failed for player_id=%s",
                     realm, player.player_id)
 
-        if delay:
-            time.sleep(delay)
-
     result = {
         'realm': realm,
         'hot_set_size': len(members),
+        'processed': processed,
+        'wg_calls': wg_calls,
+        'max_pulls': max_pulls,
+        'stopped_early': stopped_early,
+        'remaining': max(0, len(members) - processed),
         'observed': observed,
         'obs_skipped_fresh': obs_skipped_fresh,
         'obs_skipped_hidden': obs_skipped_hidden,
@@ -460,23 +512,32 @@ def capture_hot_players(realm: str, *, logger=logger) -> dict:
 
 def backfill_hot_players(realm: str, *, dry_run: bool = False,
                          logger=logger) -> dict:
-    """One-time seed: fill a realm's hot queue to the cap with most-active players.
+    """One-time seed: fill a realm's hot queue to the cap with the most-active
+    players the observation floor is NOT already keeping fresh.
 
     Selects active (``last_battle_date`` within ``HOT_BACKFILL_ACTIVE_DAYS``=7),
     non-hidden players ordered by ``pvp_battles`` desc (recent + high volume),
-    skips anyone already in the queue, and inserts ``source='backfill'`` rows up to
-    the remaining ``HOT_PLAYERS_MAX`` headroom. Each seed scores BELOW the
-    engagement floor (``_backfill_score``) so it ranks under every engaged member
-    and is the first cap-trimmed; ``maintain_hot_players`` protects it from
+    skips anyone already in the queue, **and excludes players who already have a
+    ``BattleObservation`` within ``HOT_OBSERVE_FLOOR_HOURS``** — i.e. the ones the
+    capture sweep would skip-if-fresh. Mirroring that skip predicate means each
+    seeded slot is a player the sweep will actually *pull* (coverage the floor is
+    missing), not a wasted skip. It inserts ``source='backfill'`` rows up to the
+    remaining ``HOT_PLAYERS_MAX`` headroom. Each seed scores BELOW the engagement
+    floor (``_backfill_score``) so it ranks under every engaged member and is the
+    first cap-trimmed; ``maintain_hot_players`` protects it from
     inactivity-eviction and graduates it to 'engagement' if it later earns
-    view-recurrence. Idempotent — re-running tops the queue back up to the cap
-    without duplicating. No WG calls (pure DB); the nightly capture/freshness
-    sweeps do the actual observation/snapshot/freshness work.
+    view-recurrence. Idempotent — re-running tops the queue back up to the cap.
+    No WG calls (pure DB); the nightly capture sweep does the observation work.
+
+    Because the seed is all floor-missed (expensive) players, the capture sweep is
+    work-budgeted and rotates by coverage age — see ``capture_hot_players`` and
+    [[project_hot_queue_stale_seed_starves]]; an unbudgeted all-pull sweep starves.
     """
     cap = _hot_players_max()
     active_days = _backfill_active_days()
     today = timezone.now().date()
     cutoff = today - timedelta(days=active_days)
+    stale_before = timezone.now() - timedelta(hours=_observe_floor_hours())
 
     current_ids = set(
         HotPlayer.objects.filter(realm=realm)
@@ -489,10 +550,16 @@ def backfill_hot_players(realm: str, *, dry_run: bool = False,
         logger.info("hot_players[%s] backfill (full): %s", realm, result)
         return result
 
+    # Exclude players the floor already covers (fresh obs within the capture skip
+    # window) so the seed holds only players the sweep will actually pull.
+    fresh_obs = BattleObservation.objects.filter(
+        player_id=OuterRef('id'), observed_at__gte=stale_before)
     candidates = list(
         Player.objects
         .filter(realm=realm, is_hidden=False, last_battle_date__gte=cutoff)
         .exclude(player_id__in=current_ids)
+        .annotate(_has_fresh_obs=Exists(fresh_obs))
+        .filter(_has_fresh_obs=False)
         .order_by('-pvp_battles', '-last_battle_date')
         .values_list('id', 'pvp_battles')[:slots]
     )

--- a/server/warships/signals.py
+++ b/server/warships/signals.py
@@ -206,19 +206,23 @@ def register_periodic_schedules(sender, **kwargs):
     PeriodicTask.objects.filter(name="landing-page-warmer").delete()
 
     # -- Realm top-ships treemap warmer --
-    # The treemap is a static per-season count over the most recently completed
-    # fixed 2-week ship season (cached under a season-tagged key). A daily warm
-    # is still cheap and keeps the cache fresh across a season boundary, when the
-    # completed-season key advances. Fires at hour 0, striped per realm by a few
-    # minutes (NA :05, EU :10, ASIA :15 by default) so the three realms don't
-    # recompute concurrently on the background worker.
+    # The treemap + inline tier/type list aggregate over the rolling trailing
+    # window the /ship leaderboards read (cached under a window-end-tagged key).
+    # The warm must run AFTER that realm's nightly ship snapshot lands so it warms
+    # the *current* window — otherwise the first post-snapshot visitor pays a cold
+    # 14-day GROUP-BY. Fires 1h after the snapshot hour (snapshot is :30; this is
+    # the next hour, striped per realm by a few minutes — NA :05, EU :10, ASIA :15
+    # by default) so the three realms don't recompute concurrently.
     top_ships_warm_minute = int(os.getenv("TOP_SHIPS_WARM_MINUTE", "5"))
+    ship_badge_snapshot_hour = int(os.getenv("SHIP_BADGE_SNAPSHOT_HOUR", "2"))
     for realm in sorted(VALID_REALMS):
         realm_minute = (top_ships_warm_minute +
                         REALM_INTERVAL_OFFSETS.get(realm, 0) * 5) % 60
+        realm_hour = (ship_badge_snapshot_hour + 1 +
+                      REALM_CRAWL_CRON_HOURS.get(realm, 0)) % 24
         top_ships_warm_schedule, _ = CrontabSchedule.objects.get_or_create(
             minute=str(realm_minute),
-            hour="0",
+            hour=str(realm_hour),
             day_of_week="*",
             day_of_month="*",
             month_of_year="*",
@@ -233,7 +237,7 @@ def register_periodic_schedules(sender, **kwargs):
                 "enabled": True,
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"realm": realm}),
-                "description": f"Daily warm of top-ships treemap caches (random+ranked) + tier/type ship-list buckets, last completed ship season ({realm.upper()}).",
+                "description": f"Daily warm of top-ships treemap caches (random+ranked) + tier/type ship-list buckets over the rolling ship-standings window, ~1h after the nightly snapshot ({realm.upper()}).",
             },
         )
 

--- a/server/warships/tasks.py
+++ b/server/warships/tasks.py
@@ -1051,11 +1051,11 @@ def warm_realm_top_ships_task(self, realm=DEFAULT_REALM):
 
     Recomputes both treemap modes (random + ranked) and every tier×type ship
     list bucket for the realm once per day (force-refresh) and writes them to
-    Redis under their season-tagged keys, so the first visitor hits a warm cache
-    instead of the aggregation. Both surfaces are static per-season aggregations
-    over the most recently completed fixed 2-week ship season; the daily warm
-    keeps the caches fresh across a season boundary (the keys change when the
-    completed season advances). Mirrors the other per-realm landing warmers.
+    Redis under their window-end-tagged keys, so the first visitor hits a warm
+    cache instead of the aggregation. Both surfaces aggregate over the rolling
+    trailing window the /ship leaderboards read (anchored on the latest snapshot's
+    captured_on); the daily warm runs after the nightly snapshot so it warms the
+    current window. Mirrors the other per-realm landing warmers.
 
     The tier/type list (`compute_realm_ships_by_tier_type`, backing the landing
     drill-down filter) is a live `BattleEvent` GROUP-BY — expensive to compute

--- a/server/warships/tests/test_hot_players.py
+++ b/server/warships/tests/test_hot_players.py
@@ -253,6 +253,24 @@ class BackfillSeedTests(TestCase):
         hp2 = HotPlayer.objects.get(player__player_id=8002)
         self.assertGreater(hp1.hot_score, hp2.hot_score)
 
+    def test_excludes_players_the_floor_keeps_fresh(self):
+        # The seed must skip players the capture sweep would skip-if-fresh: those
+        # with a BattleObservation within HOT_OBSERVE_FLOOR_HOURS. Only the
+        # floor-missed (stale) player should be seeded.
+        fresh = _mk_player(8011, pvp_battles=9000)   # highest volume, but fresh
+        stale = _mk_player(8012, pvp_battles=5000)   # lower volume, floor-missed
+        BattleObservation.objects.create(player=fresh, pvp_battles=9000)  # now
+        obs = BattleObservation.objects.create(player=stale, pvp_battles=5000)
+        BattleObservation.objects.filter(pk=obs.pk).update(
+            observed_at=timezone.now() - timedelta(hours=30))   # past the window
+        with _hot_env(HOT_OBSERVE_FLOOR_HOURS="20", HOT_PLAYERS_MAX="5"):
+            res = backfill_hot_players("na")
+        self.assertEqual(res['added'], 1)            # only the stale player
+        seeds = set(HotPlayer.objects.filter(
+            realm="na", source=HotPlayer.SOURCE_BACKFILL)
+            .values_list("player__player_id", flat=True))
+        self.assertEqual(seeds, {8012})              # fresh 8011 excluded
+
     def test_seed_scores_below_engagement_floor(self):
         # Even a huge-battle seed ranks under the weakest surviving engaged member
         # (active_days=2 -> score 2_000_000).
@@ -414,6 +432,60 @@ class CaptureSweepTests(TestCase):
             res = capture_hot_players("na")
         self.assertEqual(res["obs_skipped_hidden"], 1)
         self.assertEqual(res["observed"], 0)
+
+    def _backfill_member(self, pid, *, last_observed_at=None, hot_score=1000.0,
+                         realm="na"):
+        p = _mk_player(pid, realm=realm)
+        return HotPlayer.objects.create(
+            player=p, realm=realm, source=HotPlayer.SOURCE_BACKFILL,
+            hot_score=hot_score, last_observed_at=last_observed_at)
+
+    @patch("warships.incremental_battles.record_observation_and_diff")
+    @patch("warships.data.update_snapshot_data")
+    def test_capture_budget_stops_early(self, mock_snap, mock_obs):
+        # 10 floor-missed (no observation) backfill members, budget of 4 WG calls:
+        # the sweep must pull exactly 4 and defer the rest, never the whole set.
+        # This is the ceiling the 540s incident slipped past — assert it directly.
+        mock_obs.return_value = {"status": "completed"}
+        for pid in range(8701, 8711):
+            self._backfill_member(pid)
+        with _hot_env(HOT_PLAYERS_CAPTURE_DELAY="0"):
+            res = capture_hot_players("na", max_pulls=4)
+        self.assertEqual(mock_obs.call_count, 4)
+        self.assertEqual(res["wg_calls"], 4)
+        self.assertTrue(res["stopped_early"])
+        self.assertEqual(res["remaining"], 6)
+
+    @patch("warships.incremental_battles.record_observation_and_diff")
+    @patch("warships.data.update_snapshot_data")
+    def test_capture_rotates_oldest_coverage_first(self, mock_snap, mock_obs):
+        # Backfill members all floor-missed but with distinct coverage ages. With a
+        # budget of 2, the sweep must spend it on the LEAST-recently-covered first
+        # (NULL, then oldest) so the set drains round-robin instead of starving.
+        mock_obs.return_value = {"status": "completed"}
+        now = timezone.now()
+        self._backfill_member(8801, last_observed_at=None)                       # oldest
+        self._backfill_member(8802, last_observed_at=now - timedelta(hours=50))
+        self._backfill_member(8803, last_observed_at=now - timedelta(hours=25))  # newest
+        with _hot_env(HOT_PLAYERS_CAPTURE_DELAY="0"):
+            res = capture_hot_players("na", max_pulls=2)
+        pulled_ids = [c.args[0] for c in mock_obs.call_args_list]
+        self.assertEqual(pulled_ids, [8801, 8802])   # NULL first, then 50h-old
+        self.assertEqual(res["wg_calls"], 2)
+
+    @patch("warships.incremental_battles.record_observation_and_diff")
+    @patch("warships.data.update_snapshot_data")
+    def test_capture_priority_members_before_backfill(self, mock_snap, mock_obs):
+        # An engagement member is sweep-priority over a backfill seed regardless of
+        # coverage age — budget of 1 must spend on engagement first.
+        mock_obs.return_value = {"status": "completed"}
+        self._backfill_member(8901, last_observed_at=None)   # oldest by age
+        self._hot_member(8902)                               # engagement, priority
+        with _hot_env(HOT_PLAYERS_CAPTURE_DELAY="0"):
+            res = capture_hot_players("na", max_pulls=1)
+        pulled_ids = [c.args[0] for c in mock_obs.call_args_list]
+        self.assertEqual(pulled_ids, [8902])   # engagement before the older backfill
+        self.assertTrue(res["stopped_early"])
 
 
 class CommandErgonomicsTests(TestCase):

--- a/server/warships/tests/test_realm_ships_by_tier_type.py
+++ b/server/warships/tests/test_realm_ships_by_tier_type.py
@@ -2,21 +2,23 @@
 
 Backs the landing-page filterable table under the treemap
 (``compute_realm_ships_by_tier_type`` + the ``/api/realm/<realm>/ships`` view).
-Pins the win-rate ordering, the tier+type filter, the season window boundaries,
+Pins the win-rate ordering, the tier+type filter, the rolling-window boundaries,
 realm/mode isolation, nullable-damage handling, the min-battles floor, the
 snapshot restriction (only ships with a drill-down board are listed), and the
-view's validation (404 unknown realm, 400 bad tier/type).
+view's validation (404 unknown realm, 400 bad tier/type). The window is the
+rolling trailing ``SHIP_LEADERBOARD_WINDOW_DAYS`` anchored on the realm's latest
+``ShipTopPlayerSnapshot.captured_on`` — 1:1 with the /ship leaderboards.
 """
 
 from datetime import timedelta
 
 from django.core.cache import cache
 from django.test import TestCase
+from django.utils import timezone
 
 from warships.data import (
     _season_window_datetimes,
     compute_realm_ships_by_tier_type,
-    most_recent_completed_season,
 )
 from warships.models import (
     BattleEvent, BattleObservation, Player, Ship, ShipTopPlayerSnapshot,
@@ -43,14 +45,17 @@ class RealmShipsByTierTypeTests(TestCase):
                             ship_type="Battleship", tier=10)
         Ship.objects.create(ship_id=T9_DD, name="Fletcher", nation="usa",
                             ship_type="Destroyer", tier=9)
-        self.season_idx, self.season_start, self.season_end = most_recent_completed_season()
+        # Anchor the rolling window on captured_on=today (the snapshots created by
+        # _snapshot share this date, so they are the candidate set).
+        self.captured_on = timezone.now().date()
+        self.window_start_d = self.captured_on - timedelta(days=14)
         self.window_start, self.window_end = _season_window_datetimes(
-            self.season_start, self.season_end)
+            self.window_start_d, self.captured_on)
 
     def _snapshot(self, ship_id, realm="na"):
-        """Mark a ship 'ranked' for the latest season so it's a list candidate."""
+        """Mark a ship 'ranked' for the latest window so it's a list candidate."""
         ShipTopPlayerSnapshot.objects.create(
-            captured_on=self.season_start, realm=realm, ship_id=ship_id,
+            captured_on=self.captured_on, realm=realm, ship_id=ship_id,
             ship_name="x", rank=1, player=self.player, win_rate=50.0, battles=1)
 
     def _event(self, ship_id, battles, wins, *, damage=0, frags=0,
@@ -81,7 +86,9 @@ class RealmShipsByTierTypeTests(TestCase):
 
         self.assertEqual(payload["tier"], 10)
         self.assertEqual(payload["ship_type"], "Destroyer")
-        self.assertEqual(payload["season_index"], self.season_idx)
+        self.assertEqual(payload["window_days"], 14)
+        self.assertEqual(payload["captured_on"], self.captured_on.isoformat())
+        self.assertNotIn("season_index", payload)
         ids = [s["ship_id"] for s in payload["ships"]]
         self.assertEqual(ids, [GEARING, SHIMA])  # 60% before 55%
         g = payload["ships"][0]
@@ -105,13 +112,13 @@ class RealmShipsByTierTypeTests(TestCase):
             "na", tier=10, ship_type="Destroyer", use_cache=False)
         self.assertEqual([s["ship_id"] for s in payload["ships"]], [SHIMA])
 
-    def test_window_excludes_neighbouring_seasons(self):
+    def test_window_excludes_neighbouring_periods(self):
         self._snapshot(SHIMA)
         self._event(SHIMA, battles=200, wins=100, detected_at=self.window_start)  # in
         self._event(SHIMA, battles=300, wins=300,
-                    detected_at=self.window_end + timedelta(hours=6))   # current season
+                    detected_at=self.window_end + timedelta(hours=6))   # past window
         self._event(SHIMA, battles=300, wins=300,
-                    detected_at=self.window_start - timedelta(hours=1))  # prior
+                    detected_at=self.window_start - timedelta(hours=1))  # before
 
         payload = compute_realm_ships_by_tier_type(
             "na", tier=10, ship_type="Destroyer", use_cache=False)
@@ -157,6 +164,15 @@ class RealmShipsByTierTypeTests(TestCase):
             "na", tier=10, ship_type="Destroyer", use_cache=False)
         self.assertEqual(payload["ships"], [])
 
+    def test_no_snapshot_returns_empty_with_null_captured_on(self):
+        # No snapshot anywhere for the realm → captured_on is None and the list is
+        # empty (the candidate set comes from the latest snapshot).
+        self._event(SHIMA, battles=500, wins=300)
+        payload = compute_realm_ships_by_tier_type(
+            "na", tier=10, ship_type="Destroyer", use_cache=False)
+        self.assertIsNone(payload["captured_on"])
+        self.assertEqual(payload["ships"], [])
+
 
 class RealmShipsByTierTypeWarmTests(TestCase):
     """The daily warm_realm_top_ships_task pre-populates the tier/type buckets.
@@ -171,12 +187,11 @@ class RealmShipsByTierTypeWarmTests(TestCase):
             name="warm_bench", player_id=888004, realm="na", pvp_battles=1000)
         Ship.objects.create(ship_id=SHIMA, name="Shimakaze", nation="japan",
                             ship_type="Destroyer", tier=10)
-        self.season_idx, self.season_start, self.season_end = (
-            most_recent_completed_season())
+        self.captured_on = timezone.now().date()
         self.window_start, _ = _season_window_datetimes(
-            self.season_start, self.season_end)
+            self.captured_on - timedelta(days=14), self.captured_on)
         ShipTopPlayerSnapshot.objects.create(
-            captured_on=self.season_start, realm="na", ship_id=SHIMA,
+            captured_on=self.captured_on, realm="na", ship_id=SHIMA,
             ship_name="Shimakaze", rank=1, player=self.player,
             win_rate=50.0, battles=1)
         obs_a = BattleObservation.objects.create(player=self.player, pvp_battles=1)
@@ -192,7 +207,7 @@ class RealmShipsByTierTypeWarmTests(TestCase):
     def _bucket_key(self, tier, ship_type):
         return realm_cache_key(
             "na",
-            f"ships-by:random:season{self.season_idx}:t{tier}:{ship_type}")
+            f"ships-by:random:win{self.captured_on.isoformat()}:t{tier}:{ship_type}")
 
     def test_warm_populates_tier_type_bucket_cache(self):
         from warships.tasks import warm_realm_top_ships_task
@@ -223,10 +238,10 @@ class RealmShipsByTierTypeViewTests(TestCase):
             name="view_bench", player_id=888003, realm="na", pvp_battles=10)
         Ship.objects.create(ship_id=SHIMA, name="Shimakaze", nation="japan",
                             ship_type="Destroyer", tier=10)
-        idx, start, end = most_recent_completed_season()
         ShipTopPlayerSnapshot.objects.create(
-            captured_on=start, realm="na", ship_id=SHIMA, ship_name="Shimakaze",
-            rank=1, player=self.player, win_rate=50.0, battles=1)
+            captured_on=timezone.now().date(), realm="na", ship_id=SHIMA,
+            ship_name="Shimakaze", rank=1, player=self.player,
+            win_rate=50.0, battles=1)
 
     def test_happy_path_returns_payload(self):
         resp = self.client.get("/api/realm/na/ships/?tier=10&type=Destroyer")

--- a/server/warships/tests/test_realm_top_ships.py
+++ b/server/warships/tests/test_realm_top_ships.py
@@ -1,25 +1,29 @@
 """Window-boundary tests for the realm top-ships treemap.
 
-The treemap is a *static per-season count* over the most recently completed fixed
-2-week ship season — i.e. the window is ``[season_start, season_end)`` for the
-season returned by ``most_recent_completed_season`` (the same window the /ship
-leaderboard + profile medals reflect). These tests pin the off-by-one boundaries
-(in-progress current season excluded, season-start included, day-before excluded)
-and the per-ship summation, since that is the failure mode most likely to slip
-when the window definition changes.
+The treemap aggregates ``BattleEvent`` over the **rolling trailing
+``SHIP_LEADERBOARD_WINDOW_DAYS`` window the /ship leaderboards read** — i.e.
+``[captured_on - window_days, captured_on)`` for the realm's most recent
+``ShipTopPlayerSnapshot.captured_on`` (see ``latest_ship_snapshot_window``). These
+tests pin the off-by-one boundaries (window-start included, the current day past
+the window excluded, the day before excluded) and the per-ship summation, since
+that is the failure mode most likely to slip when the window definition changes.
 """
 
 from datetime import timedelta
 
 from django.core.cache import cache
 from django.test import TestCase
+from django.utils import timezone
 
 from warships.data import (
+    SHIP_LEADERBOARD_WINDOW_DAYS,
     _season_window_datetimes,
     compute_realm_top_ships,
-    most_recent_completed_season,
+    latest_ship_snapshot_window,
 )
-from warships.models import BattleEvent, BattleObservation, Player, Ship
+from warships.models import (
+    BattleEvent, BattleObservation, Player, Ship, ShipTopPlayerSnapshot,
+)
 
 
 class RealmTopShipsWindowTests(TestCase):
@@ -34,12 +38,17 @@ class RealmTopShipsWindowTests(TestCase):
             ship_id=1, name="Yamato", nation="japan",
             ship_type="Battleship", tier=10,
         )
-        # The window is the most recently completed fixed 2-week ship season. The
-        # project runs USE_TZ=False, so _season_window_datetimes returns naive
-        # datetimes — match the production code path.
-        self.season_idx, self.season_start, self.season_end = most_recent_completed_season()
+        # Anchor the realm's rolling window on a snapshot's captured_on, exactly as
+        # the /ship leaderboards do. The project runs USE_TZ=False, so
+        # _season_window_datetimes returns naive datetimes — match the prod path.
+        self.captured_on = timezone.now().date()
+        ShipTopPlayerSnapshot.objects.create(
+            captured_on=self.captured_on, realm="na", ship_id=1,
+            ship_name="Yamato", rank=1, player=self.player,
+            win_rate=50.0, battles=1)
+        _, self.window_start_d, self.window_end_d = latest_ship_snapshot_window("na")
         self.window_start, self.window_end = _season_window_datetimes(
-            self.season_start, self.season_end)
+            self.window_start_d, self.window_end_d)
 
     def _event(self, ship_id, ship_name, battles, detected_at, mode="random"):
         """Create one BattleEvent at an exact detected_at.
@@ -59,23 +68,24 @@ class RealmTopShipsWindowTests(TestCase):
         BattleEvent.objects.filter(pk=ev.pk).update(detected_at=detected_at)
         return ev
 
-    def test_window_is_completed_season_and_excludes_neighbours(self):
-        # In-window: mid-season and exactly the season-start boundary (gte).
+    def test_window_is_rolling_and_excludes_neighbours(self):
+        # In-window: mid-window and exactly the window-start boundary (gte).
         self._event(1, "Yamato", 5, self.window_start + timedelta(days=1, hours=12))
         self._event(1, "Yamato", 3, self.window_start)  # exact lower bound, included
-        # Out-of-window: the in-progress current season (>= season_end), and the
-        # instant just before season_start.
+        # Out-of-window: the current day past the window end (>= window_end), and
+        # the instant just before window_start.
         self._event(2, "Shimakaze", 99, self.window_end + timedelta(hours=6))
         self._event(3, "Montana", 77, self.window_start - timedelta(hours=1))
 
         payload = compute_realm_top_ships("na", mode="random", use_cache=False)
 
-        self.assertEqual(payload["days"], 14)
-        self.assertEqual(payload["season_index"], self.season_idx)
-        self.assertEqual(payload["season_start"], self.season_start.isoformat())
-        self.assertEqual(payload["season_end"], self.season_end.isoformat())
-        self.assertEqual(payload["window_start"], self.window_start.isoformat())
-        self.assertEqual(payload["window_end"], self.window_end.isoformat())
+        self.assertEqual(payload["window_days"], SHIP_LEADERBOARD_WINDOW_DAYS)
+        self.assertEqual(payload["captured_on"], self.captured_on.isoformat())
+        self.assertEqual(payload["window_start"], self.window_start_d.isoformat())
+        self.assertEqual(payload["window_end"], self.window_end_d.isoformat())
+        # No fixed-season framing under the rolling model.
+        self.assertNotIn("season_start", payload)
+        self.assertNotIn("season_end", payload)
 
         by_id = {s["ship_id"]: s for s in payload["ships"]}
         # Ship 1: both in-window rows summed (5 + 3); neighbours excluded.
@@ -83,8 +93,24 @@ class RealmTopShipsWindowTests(TestCase):
         self.assertEqual(by_id[1]["battles"], 8)
         self.assertEqual(by_id[1]["ship_type"], "Battleship")
         self.assertEqual(by_id[1]["tier"], 10)
-        self.assertNotIn(2, by_id)  # in-progress current season excluded
-        self.assertNotIn(3, by_id)  # before season_start excluded
+        self.assertNotIn(2, by_id)  # current day past window end excluded
+        self.assertNotIn(3, by_id)  # before window_start excluded
+
+    def test_falls_back_to_trailing_today_window_without_snapshot(self):
+        # With no snapshot for the realm, the window falls back to a trailing
+        # window ending today and captured_on is None.
+        ShipTopPlayerSnapshot.objects.all().delete()
+        cache.clear()
+        captured_on, window_start_d, window_end_d = latest_ship_snapshot_window("na")
+        self.assertIsNone(captured_on)
+        self.assertEqual(window_end_d, timezone.now().date())
+        self.assertEqual(
+            window_start_d,
+            timezone.now().date() - timedelta(days=SHIP_LEADERBOARD_WINDOW_DAYS))
+
+        payload = compute_realm_top_ships("na", mode="random", use_cache=False)
+        self.assertIsNone(payload["captured_on"])
+        self.assertEqual(payload["window_end"], window_end_d.isoformat())
 
     def test_mode_and_realm_isolation(self):
         # A ranked event and a different-realm event must not bleed into the

--- a/server/warships/tests/test_ship_badges.py
+++ b/server/warships/tests/test_ship_badges.py
@@ -5,11 +5,10 @@ floor, the per-ship population guard, tier scope, realm isolation, hidden
 exclusion, the trailing rolling window, idempotency, captured_on=run-date,
 displaced-holder cache invalidation), `get_player_ship_badges` (badges = ranks
 1..N only, worn while held), `get_ship_leaderboard` + the `ship_leaderboard`
-endpoint, and the task's enable gate. The fixed-season helpers still back the
-realm treemap and keep their own tests below.
+endpoint, and the task's enable gate.
 See agents/runbooks/runbook-ship-badges-rolling-2026-06-14.md.
 """
-from datetime import date, timedelta
+from datetime import timedelta
 from unittest import mock
 
 from django.core.cache import cache
@@ -17,14 +16,10 @@ from django.test import TestCase
 from django.utils import timezone
 
 from warships.data import (
-    SHIP_SEASON_EPOCH,
     compute_ship_top_player_snapshot,
-    current_season_index,
     get_player_ship_badges,
     get_players_ship_badges_bulk,
     get_ship_leaderboard,
-    most_recent_completed_season,
-    ship_season_bounds,
 )
 from warships.models import (
     BattleEvent,
@@ -261,13 +256,15 @@ class ShipBadgeSnapshotTests(TestCase):
 
     def test_non_t10_not_in_treemap_is_ignored(self):
         # A non-T10 ship that is NOT in the realm treemap top-25 isn't a target.
-        # (These events are stamped "today", which compute_realm_top_ships's
-        # previous-7-full-UTC-days window excludes, so the ship never enters the
-        # treemap set here.)
+        # The treemap now aggregates the same rolling window as the snapshot, so a
+        # recent-but-out-of-tier ship could enter it; mock the treemap empty to
+        # isolate the "not a target" path, decoupled from the treemap's window.
         for i in range(5):
             self._event(self._player(f"T9p{i}"), T9_SHIP, battles=30, wins=20)
 
-        result = self._run("na")
+        with mock.patch("warships.data.compute_realm_top_ships",
+                        return_value={"ships": []}):
+            result = self._run("na")
 
         self.assertEqual(result["ranked_rows"], 0)
         self.assertFalse(
@@ -276,10 +273,8 @@ class ShipBadgeSnapshotTests(TestCase):
     def test_non_t10_in_treemap_is_included(self):
         # A non-T10 ship that IS among the most-played (returned by the realm
         # treemap) is unioned into the snapshot target set and ranked, even though
-        # it isn't Tier 10. The treemap window is now the completed ship season
-        # (not a rolling 7d, per the treemap-season-alignment change), so mock the
-        # treemap to exercise the union mechanism directly, decoupled from its
-        # window.
+        # it isn't Tier 10. Mock the treemap to exercise the union mechanism
+        # directly, decoupled from its window.
         for i in range(3):
             self._event(self._player(f"T9p{i}"), T9_SHIP, battles=30,
                         wins=20 + i, detected_days_ago=2)
@@ -671,26 +666,6 @@ class ShipBadgeSnapshotTests(TestCase):
         self.assertNotIn("season_start", lb)
         self.assertNotIn("season_end", lb)
         self.assertNotIn("next_window_open", lb)
-
-
-class ShipSeasonHelpersTests(TestCase):
-    """Pure date math for the fixed 2-week seasons (epoch = Mon 11 May 2026).
-
-    The ship badges/board are now a rolling trailing window; these helpers remain
-    only because the realm treemap (`compute_realm_top_ships`) still buckets by a
-    fixed, immutable calendar season for its per-season cache key."""
-
-    def test_epoch_and_bounds(self):
-        self.assertEqual(SHIP_SEASON_EPOCH, date(2026, 5, 11))
-        self.assertEqual(ship_season_bounds(0), (date(2026, 5, 11), date(2026, 5, 25)))
-        self.assertEqual(ship_season_bounds(1)[0], date(2026, 5, 25))
-
-    def test_current_index_and_completed(self):
-        d = date(2026, 6, 5)  # mid W22-23 (season index 1)
-        self.assertEqual(current_season_index(d), 1)
-        idx, start, end = most_recent_completed_season(d)
-        self.assertEqual((idx, start, end),
-                         (0, date(2026, 5, 11), date(2026, 5, 25)))
 
 
 class MaterializeBestSnapshotWarmChainTests(TestCase):

--- a/server/warships/tests/test_views.py
+++ b/server/warships/tests/test_views.py
@@ -4950,3 +4950,81 @@ class SitemapEntitiesTests(TestCase):
         names = [p["name"] for p in response.json()["players"]]
         self.assertNotIn("OnlyOnce", names)
         self.assertNotIn("StaleVisit", names)
+
+
+class RecordClanLookupDebounceTests(TestCase):
+    """`_record_clan_lookup` runs on every clan read (incl. each hydration poll
+    and each response-cache hit), so it must not write + bust the landing cache
+    unless `last_lookup` has actually gone stale past the debounce interval."""
+
+    def setUp(self):
+        cache.clear()
+
+    @patch("warships.views.invalidate_landing_clan_caches")
+    def test_records_when_never_looked_up(self, mock_invalidate):
+        from warships.views import _record_clan_lookup
+        clan = Clan.objects.create(
+            clan_id=9701, name="NeverLookedUp", members_count=1,
+            last_fetch=timezone.now(), last_lookup=None)
+        _record_clan_lookup(clan, realm="na")
+        mock_invalidate.assert_called_once()
+        self.assertIsNotNone(clan.last_lookup)
+
+    @patch("warships.views.invalidate_landing_clan_caches")
+    def test_skips_within_interval(self, mock_invalidate):
+        from warships.views import _record_clan_lookup
+        now = timezone.now()
+        clan = Clan.objects.create(
+            clan_id=9702, name="RecentlyLookedUp", members_count=1,
+            last_fetch=now, last_lookup=now)
+        _record_clan_lookup(clan, realm="na")
+        # Within the debounce window: no landing-cache bust, no write.
+        mock_invalidate.assert_not_called()
+        self.assertEqual(clan.last_lookup, now)
+
+    @patch("warships.views.invalidate_landing_clan_caches")
+    def test_records_again_once_stale(self, mock_invalidate):
+        from warships.views import _record_clan_lookup, CLAN_LOOKUP_RECORD_INTERVAL
+        stale = timezone.now() - CLAN_LOOKUP_RECORD_INTERVAL - timedelta(minutes=1)
+        clan = Clan.objects.create(
+            clan_id=9703, name="StaleLookup", members_count=1,
+            last_fetch=timezone.now(), last_lookup=stale)
+        _record_clan_lookup(clan, realm="na")
+        mock_invalidate.assert_called_once()
+        self.assertGreater(clan.last_lookup, stale)
+        # An immediate repeat is now debounced.
+        mock_invalidate.reset_mock()
+        _record_clan_lookup(clan, realm="na")
+        mock_invalidate.assert_not_called()
+
+
+class ClanMemberBadgesCacheTests(TestCase):
+    """Badges are recomputed only nightly, so the hydration poll loop must not
+    re-run the 3-query bulk fetch on every poll — `_clan_member_badges_cached`
+    caches per clan, keyed on the member-pk set so a roster change rotates it."""
+
+    def setUp(self):
+        cache.clear()
+
+    @patch("warships.data.get_players_ship_badges_bulk")
+    def test_cached_across_calls_same_roster(self, mock_bulk):
+        from warships.views import _clan_member_badges_cached
+        mock_bulk.return_value = {101: [{"ship_id": 1, "rank": 1}]}
+
+        first = _clan_member_badges_cached("4242", "na", [101, 102, 103])
+        second = _clan_member_badges_cached("4242", "na", [103, 101, 102])  # reordered
+
+        # Underlying bulk fetch ran once; the second (poll) call hit cache.
+        mock_bulk.assert_called_once()
+        self.assertEqual(first, second)
+
+    @patch("warships.data.get_players_ship_badges_bulk")
+    def test_roster_change_rotates_key(self, mock_bulk):
+        from warships.views import _clan_member_badges_cached
+        mock_bulk.return_value = {}
+
+        _clan_member_badges_cached("4242", "na", [101, 102])
+        _clan_member_badges_cached("4242", "na", [101, 102, 104])  # new member joined
+
+        # Different roster -> different cache key -> recompute.
+        self.assertEqual(mock_bulk.call_count, 2)

--- a/server/warships/tests/test_views.py
+++ b/server/warships/tests/test_views.py
@@ -8,7 +8,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from warships.landing import LANDING_CLANS_BEST_CACHE_KEY, LANDING_CLANS_BEST_PUBLISHED_CACHE_KEY, LANDING_CLANS_CACHE_KEY, LANDING_CLANS_PUBLISHED_CACHE_KEY, LANDING_PLAYER_LIMIT, landing_best_clan_cache_key, landing_best_clan_published_cache_key, landing_player_cache_key, landing_player_published_cache_key, warm_landing_page_content
-from warships.models import Player, Clan, PlayerExplorerSummary, realm_cache_key, LandingPlayerBestSnapshot, Ship, ShipTopPlayerSnapshot
+from warships.models import Player, Clan, PlayerExplorerSummary, realm_cache_key, LandingPlayerBestSnapshot, Ship, ShipTopPlayerSnapshot, EntityVisitDaily
 from warships.views import PUBLIC_API_THROTTLES, landing_players, _missing_player_lookup_cache_key
 
 
@@ -4884,3 +4884,69 @@ class ClanMemberBadgesCacheTests(TestCase):
 
         # Different roster -> different cache key -> recompute.
         self.assertEqual(mock_bulk.call_count, 2)
+
+
+class SitemapEntitiesTests(TestCase):
+    """The sitemap must not emit hidden / dead-end player URLs (thin content)."""
+
+    def setUp(self):
+        cache.clear()
+
+    def _visit(self, pid, name, views):
+        EntityVisitDaily.objects.create(
+            date=timezone.now().date(),
+            entity_type='player',
+            entity_id=pid,
+            realm='na',
+            entity_name_snapshot=name,
+            views_deduped=views,
+            views_raw=views,
+            unique_visitors=1,
+        )
+
+    def test_sitemap_excludes_hidden_and_missing_players(self):
+        now = timezone.now()
+        # Visible player — should appear.
+        Player.objects.create(
+            name="VisiblePlayer", player_id=88001, realm="na",
+            last_fetch=now, pvp_battles=1000, is_hidden=False)
+        # Hidden player ranked ABOVE the visible one by views — must be dropped
+        # despite outranking, proving the filter isn't just a tail trim.
+        Player.objects.create(
+            name="HiddenPlayer", player_id=88002, realm="na",
+            last_fetch=now, pvp_battles=1000, is_hidden=True)
+        # Visited id with no Player row (deleted / never ingested) — must drop.
+
+        self._visit(88002, "HiddenPlayer", views=50)   # top by views
+        self._visit(88001, "VisiblePlayer", views=20)
+        self._visit(88003, "GhostPlayer", views=10)     # no Player row
+
+        response = self.client.get("/api/sitemap-entities/")
+        self.assertEqual(response.status_code, 200)
+        names = [p["name"] for p in response.json()["players"]]
+
+        self.assertIn("VisiblePlayer", names)
+        self.assertNotIn("HiddenPlayer", names)
+        self.assertNotIn("GhostPlayer", names)
+
+    def test_sitemap_drops_low_view_and_old_visits(self):
+        now = timezone.now()
+        Player.objects.create(
+            name="OnlyOnce", player_id=88010, realm="na",
+            last_fetch=now, pvp_battles=10, is_hidden=False)
+        Player.objects.create(
+            name="StaleVisit", player_id=88011, realm="na",
+            last_fetch=now, pvp_battles=10, is_hidden=False)
+        # Below the views_deduped>=2 floor.
+        self._visit(88010, "OnlyOnce", views=1)
+        # Visited outside the 30-day window.
+        EntityVisitDaily.objects.create(
+            date=(now - timedelta(days=45)).date(),
+            entity_type='player', entity_id=88011, realm='na',
+            entity_name_snapshot="StaleVisit", views_deduped=99, views_raw=99,
+            unique_visitors=1)
+
+        response = self.client.get("/api/sitemap-entities/")
+        names = [p["name"] for p in response.json()["players"]]
+        self.assertNotIn("OnlyOnce", names)
+        self.assertNotIn("StaleVisit", names)

--- a/server/warships/views.py
+++ b/server/warships/views.py
@@ -2117,18 +2117,17 @@ def sitemap_entities(request) -> Response:
 @api_view(["GET"])
 @throttle_classes(PUBLIC_API_THROTTLES)
 def realm_top_ships(request, realm: str) -> Response:
-    """Most-played ships on a realm over the most recently completed ship season.
+    """Most-played ships on a realm over the rolling ship-standings window.
 
     Powers the landing treemap: each ship is a tile sized by battles, colored
     by type and shaded by tier. Sums BattleEvent.battles_delta per ship over the
-    most recently completed fixed 2-week ship season — the same window the
-    /ship/<id> leaderboard and profile medals reflect — then joins Ship for
-    type + tier. A static per-season count: recomputed once per season
-    (season-tagged Redis key) and served from cache otherwise.
+    rolling trailing window the /ship/<id> leaderboard + profile medals read
+    (anchored on the latest ShipTopPlayerSnapshot.captured_on) — then joins Ship
+    for type + tier. Recomputed nightly (window-end-tagged Redis key, refreshed by
+    the daily warmer) and served from cache otherwise.
 
     Response shape:
-        {realm, days, season_index, season_start, season_end,
-         window_start, window_end, mode,
+        {realm, window_days, captured_on, window_start, window_end, mode,
          ships: [{ship_id, ship_name, ship_type, tier, battles}]}
     """
     from warships.data import compute_realm_top_ships
@@ -2137,9 +2136,9 @@ def realm_top_ships(request, realm: str) -> Response:
     if realm not in VALID_REALMS:
         return Response({"detail": "Unknown realm."}, status=status.HTTP_404_NOT_FOUND)
 
-    # The shared helper fixes the season window, clamps limit/mode, and handles
-    # the Redis cache (season-tagged key, TTL to the next season boundary); the
-    # daily warmer calls the same helper with use_cache=False.
+    # The shared helper resolves the rolling window, clamps limit/mode, and handles
+    # the Redis cache (window-end-tagged key, 26h TTL); the daily warmer calls the
+    # same helper with use_cache=False.
     payload = compute_realm_top_ships(
         realm,
         limit=request.query_params.get("limit", 25),
@@ -2151,18 +2150,19 @@ def realm_top_ships(request, realm: str) -> Response:
 @api_view(["GET"])
 @throttle_classes(PUBLIC_API_THROTTLES)
 def realm_ships_by_tier_type(request, realm: str) -> Response:
-    """Ships of one tier+type on a realm, ranked by win rate over the last season.
+    """Ships of one tier+type on a realm, ranked by win rate over the rolling window.
 
     Powers the landing-page inline ship leaderboard (filterable table under the
     treemap). Realm-wide win rate / avg damage / kills per battle aggregated from
-    BattleEvent over the most recently completed fixed 2-week ship season, ordered
-    by win rate descending, restricted to ships with a populated drill-down board.
-    Requires `tier` (one of the badge tiers, prod 8/9/10) and `type` (a raw WG
-    ship-type string). 404 on unknown realm; 400 on missing/invalid tier or type.
+    BattleEvent over the rolling trailing window the treemap + /ship board read
+    (anchored on the latest ShipTopPlayerSnapshot.captured_on), ordered by win rate
+    descending, restricted to ships with a populated drill-down board. Requires
+    `tier` (one of the badge tiers, prod 8/9/10) and `type` (a raw WG ship-type
+    string). 404 on unknown realm; 400 on missing/invalid tier or type.
 
     Response shape:
-        {realm, days, tier, ship_type, mode, season_index, season_start,
-         season_end, window_start, window_end,
+        {realm, window_days, tier, ship_type, mode, captured_on,
+         window_start, window_end,
          ships: [{ship_id, ship_name, ship_type, tier, nation, is_premium,
                   battles, win_rate, avg_damage, kills_per_battle}]}
     """
@@ -2202,13 +2202,13 @@ def realm_ships_by_tier_type(request, realm: str) -> Response:
 @api_view(["GET"])
 @throttle_classes(PUBLIC_API_THROTTLES)
 def ship_leaderboard(request, realm: str, ship_id: int) -> Response:
-    """Fortnight leaderboard of ranked players for one ship on a realm.
+    """Rolling-window leaderboard of ranked players for one ship on a realm.
 
     Snapshot-backed (no live aggregation): serves the latest
-    `ShipTopPlayerSnapshot` rows written weekly by
-    `snapshot_ship_top_players_task`. 404 on unknown realm or unknown ship; an
-    empty `players` list means the ship was not "ranked" in the latest window
-    (qualifying pool below the population guard). Cached 15 min.
+    `ShipTopPlayerSnapshot` rows over the trailing `SHIP_LEADERBOARD_WINDOW_DAYS`
+    window, recomputed nightly by `snapshot_ship_top_players_task`. 404 on unknown
+    realm or unknown ship; an empty `players` list means the ship was not "ranked"
+    in the latest window (qualifying pool below the population guard). Cached 15 min.
 
     Response shape:
         {realm, window_days, captured_on, ship: {...},

--- a/server/warships/views.py
+++ b/server/warships/views.py
@@ -2057,17 +2057,41 @@ def landing_best_warmup(request) -> Response:
 
 @api_view(["GET"])
 def sitemap_entities(request) -> Response:
-    """Return recently-visited players and clans for sitemap generation."""
+    """Return recently-visited players and clans for sitemap generation.
+
+    Player rows are filtered to currently-visible (non-hidden) accounts: a
+    hidden profile renders only a "stats hidden" placeholder, so emitting it to
+    the sitemap is a thin-content / dead-end URL for crawlers (~40% of the most-
+    visited players are hidden profiles). ``is_hidden`` is the last-known fetch
+    state (data.py), so worst case we transiently drop a player who just un-hid
+    — they re-enter on the next visit/refresh. We also drop visited ids with no
+    matching ``Player`` row (deleted/never-ingested → would 404).
+    """
     cutoff = (timezone.now() - timedelta(days=30)).date()
 
-    player_visits = (
+    PLAYER_LIMIT = 200
+    # Over-fetch candidates so the post-hidden-filter list still reaches the cap
+    # despite ~40% of visited players being hidden profiles.
+    PLAYER_CANDIDATE_POOL = PLAYER_LIMIT * 3
+
+    player_candidates = list(
         EntityVisitDaily.objects
         .filter(entity_type='player', date__gte=cutoff)
         .values('entity_id', 'entity_name_snapshot')
         .annotate(total_views=Sum('views_deduped'))
         .filter(total_views__gte=2)
-        .order_by('-total_views')[:200]
+        .order_by('-total_views')[:PLAYER_CANDIDATE_POOL]
     )
+
+    candidate_ids = [c['entity_id'] for c in player_candidates]
+    visible_ids = set(
+        Player.objects
+        .filter(player_id__in=candidate_ids, is_hidden=False)
+        .values_list('player_id', flat=True)
+    )
+    player_visits = [
+        c for c in player_candidates if c['entity_id'] in visible_ids
+    ][:PLAYER_LIMIT]
 
     clan_visits = (
         EntityVisitDaily.objects


### PR DESCRIPTION
Lands two related commits parked on this branch:

1. **fix(seo): exclude hidden players from sitemap-entities** (`15d3f2b`) — the original sitemap fix.
2. **feat(ship-leaderboard): realm top-ships + hot-players refresh pass** (`eda8c85`) — the ship-leaderboard / realm-top-ships UX + hot-players engagement-queue work that was developed on top of (1), sharing `views.py`/`test_views.py`.

234 touched backend tests pass on the sqlite harness (`test_hot_players`, `test_realm_top_ships`, `test_ship_badges`, `test_realm_ships_by_tier_type`, `test_views`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)