### PR TITLE
feat(landing): treemap "Previous Fortnight" copy + info icon

### DIFF
--- a/client/app/components/RealmTopShipsTreemapSVG.tsx
+++ b/client/app/components/RealmTopShipsTreemapSVG.tsx
@@ -12,6 +12,8 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import * as d3 from 'd3';
 import { fetchSharedJson } from '../lib/sharedJsonFetch';
 import { useTheme } from '../context/ThemeContext';
@@ -276,7 +278,7 @@ const RealmTopShipsTreemapSVG: React.FC<RealmTopShipsTreemapSVGProps> = ({ onSel
             <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
                 <div className="flex items-center gap-3">
                     <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                        {displayRealm.toUpperCase()} most-played ships · Last 14 days{windowLabel ? ` · ${windowLabel}` : ''}
+                        {displayRealm.toUpperCase()} most-played ships · Previous Fortnight{windowLabel ? ` · ${windowLabel}` : ''}
                     </h2>
                     <div className="flex items-center gap-1 text-xs" role="group" aria-label="Battle mode">
                         {SHIP_MODES.map((m) => (
@@ -294,6 +296,20 @@ const RealmTopShipsTreemapSVG: React.FC<RealmTopShipsTreemapSVGProps> = ({ onSel
                                 {SHIP_MODE_LABEL[m]}
                             </button>
                         ))}
+                    </div>
+                    <div className="group relative inline-flex items-center">
+                        <button
+                            type="button"
+                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] text-[var(--accent-light)] transition-colors hover:text-[var(--accent-mid)] focus:outline-none focus-visible:text-[var(--accent-mid)]"
+                            aria-label="About the most-played ships treemap and its eligibility window"
+                        >
+                            <FontAwesomeIcon icon={faCircleInfo} className="text-[10px]" aria-hidden="true" />
+                        </button>
+                        <div className="pointer-events-none absolute left-0 top-full z-20 mt-2 hidden w-[27rem] max-w-[calc(100vw-2rem)] rounded-md border border-[var(--border)] bg-[var(--bg-page)] px-3 py-3 text-left text-xs normal-case tracking-normal text-[var(--text-primary)] shadow-lg group-hover:block group-focus-within:block">
+                            <p className="font-semibold uppercase tracking-wide text-[var(--accent-mid)]">Most-played ships</p>
+                            <p className="mt-2 text-[11px] leading-5 text-[var(--text-secondary)]">The 25 most-played ships on this realm — each tile is one ship, sized by battles, colored by ship type and shaded by tier (lighter = lower tier). Tap a tile to open that ship&rsquo;s leaderboard; toggle Random / Ranked to switch battle mode.</p>
+                            <p className="mt-2 text-[11px] leading-5 text-[var(--text-secondary)]"><span className="font-semibold text-[var(--accent-mid)]">Eligibility window:</span> a rolling, trailing 14-day ship-standings window recomputed nightly — the same window the ship leaderboards and profile medals read. The dates shown are its current bounds.</p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## What

Two small landing-page changes on the realm most-played-ships treemap (`RealmTopShipsTreemapSVG.tsx`):

1. **Copy** — the time-window label above the treemap now reads **"Previous Fortnight"**.
2. **Info icon** — adds a `faCircleInfo` info icon to the right of the **Random / Ranked** filter. On hover/focus it opens a popover explaining:
   - **The treemap** — tiles are ships, sized by battles, colored by ship type, shaded by tier (lighter = lower tier); tap a tile to open that ship's leaderboard.
   - **The eligibility window** — a rolling, trailing 14-day ship-standings window recomputed nightly (the same window the ship leaderboards and profile medals read); the dates shown are its current bounds.

The icon reuses the **exact style of the existing landing-page info icons** (the Best-formula tooltips in `PlayerSearch.tsx`).

## Why the label looked like "Last season"

The **live site still renders "· Last season"** — but that's a **stale frontend build**. History of this exact `<h2>`: `Previous 7D` → `Last season` (`43f793e`) → `Last 14 days` (`1310654`, current `main` HEAD). `1310654` is on `main` but its frontend was **never deployed** (it didn't bump VERSION; prod footer + repo are both `1.25.5`, set in `1ab18ff`, an ancestor of `1310654`). So prod renders the pre-`1310654` "Last season" copy while `main` already says "Last 14 days".

This PR edits that **same `<h2>`** → **"Previous Fortnight"**. After merge + a **frontend deploy**, the live page goes straight from "Last season" to "Previous Fortnight". (That FE deploy will also ship `1310654`'s other already-merged-but-undeployed frontend changes — expected.)

## Validation
- `eslint` clean on the changed file; `tsc --noEmit` clean for `RealmTopShipsTreemapSVG.tsx` (only pre-existing errors in unrelated test files).
- Production build not run in the fresh worktree (Turbopack rejects a symlinked `node_modules`); **visual review recommended** — this PR is the review gate. No `VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)